### PR TITLE
CEDS-1074: fixed MRN parsing and tightened up the tests to cover real…

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/NotificationsController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/NotificationsController.scala
@@ -109,7 +109,7 @@ class NotificationsController @Inject()(
 
     parseXmlResult match {
       case Success(metaData) =>
-        val mrn = metaData.declaration.flatMap(_.functionalReferenceId)
+        val mrn = metaData.response.headOption.flatMap(_.declaration.flatMap(_.id))
         if (mrn.isEmpty) {
           Logger.error("Unable to determine MRN")
         }

--- a/test/uk/gov/hmrc/exports/base/ExportsTestData.scala
+++ b/test/uk/gov/hmrc/exports/base/ExportsTestData.scala
@@ -18,15 +18,15 @@ package uk.gov.hmrc.exports.base
 
 import java.util.UUID
 
-import org.joda.time.DateTime
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
 import play.api.http.{ContentTypes, HeaderNames}
 import play.api.http.HeaderNames.CONTENT_TYPE
 import play.api.mvc.Codec
 import uk.gov.hmrc.exports.models._
 import uk.gov.hmrc.wco.dec.inventorylinking.movement.response.InventoryLinkingMovementResponse
-import uk.gov.hmrc.wco.dec.{MetaData, Response}
+import uk.gov.hmrc.wco.dec.{DateTimeString, MetaData, Response, ResponseDateTimeElement, Declaration => WcoDeclaration}
 import uk.gov.hmrc.exports.controllers.CustomsHeaderNames._
-import uk.gov.hmrc.wco.dec.{Declaration => WcoDeclaration, MetaData, Response}
 
 import scala.util.Random
 
@@ -64,17 +64,20 @@ trait ExportsTestData {
   val VALID_CONVERSATIONID_HEADER: (String, String) = XConversationIdName -> conversationId
   val VALID_DUCR_HEADER: (String, String) = XDucrHeaderName -> declarantDucrValue
   val VALID_MRN_HEADER: (String, String) = XMrnHeaderName -> declarantMrnValue
-  val now: DateTime = DateTime.now
+  val now: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
 
   private lazy val responseFunctionCodes: Seq[String] =
     Seq("01", "02", "03", "05", "06", "07", "08", "09", "10", "11", "16", "17", "18")
   protected def randomResponseFunctionCode: String = responseFunctionCodes(Random.nextInt(responseFunctionCodes.length))
 
+  val dtfOut = DateTimeFormat.forPattern("yyyyMMddHHmmss")
+  def dateTimeElement(dateTimeVal : DateTime) = Some(ResponseDateTimeElement(DateTimeString("102", dateTimeVal.toString("yyyyMMdd"))))
+
   val response1: Seq[Response] = Seq(
-    Response(functionCode = randomResponseFunctionCode, functionalReferenceId = Some("123"))
-  )
+    Response(functionCode = randomResponseFunctionCode, functionalReferenceId = Some("123"), issueDateTime = dateTimeElement(now.minusHours(6))))
+
   val response2: Seq[Response] = Seq(
-    Response(functionCode = randomResponseFunctionCode, functionalReferenceId = Some("456"))
+    Response(functionCode = randomResponseFunctionCode, functionalReferenceId = Some("456"),  issueDateTime = dateTimeElement(now.minusHours(5)))
   )
 
   val notification = DeclarationNotification(now, conversationId, mrn, eori, DeclarationMetadata(), response1)

--- a/test/uk/gov/hmrc/exports/controllers/NotificationTestData.scala
+++ b/test/uk/gov/hmrc/exports/controllers/NotificationTestData.scala
@@ -42,6 +42,63 @@ trait NotificationTestData {
     <messageCode>EAL</messageCode>
   </inventoryLinkingMovementRequest>
 
+  def notificationXML(mrn: String) =
+    <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
+      <WCODataModelVersionCode>02</WCODataModelVersionCode>
+      <WCOTypeName>RES</WCOTypeName>
+      <Response>
+        <FunctionCode>02</FunctionCode>
+        <FunctionalReferenceID>1234555</FunctionalReferenceID>
+        <IssueDateTime>
+          <DateTimeString formatCode="304">20190226085021Z</DateTimeString>
+        </IssueDateTime>
+        <Declaration>
+          <ID>{mrn}</ID>
+        </Declaration>
+      </Response>
+    </MetaData>
+
+  def exampleRejectNotification(mrn: String) = <MetaData>
+    <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
+    <WCOTypeName>RES</WCOTypeName>
+    <ResponsibleCountryCode/>
+    <ResponsibleAgencyName/>
+    <AgencyAssignedCustomizationCode/>
+    <AgencyAssignedCustomizationVersionCode/>
+    <Response>
+      <FunctionCode>03</FunctionCode>
+      <FunctionalReferenceID>6be6c6f61f0346748016b823eeda669d</FunctionalReferenceID>
+      <IssueDateTime>
+        <DateTimeString formatCode="304">20190328092916Z</DateTimeString>
+      </IssueDateTime>
+      <Error>
+        <ValidationCode>CDS12050</ValidationCode>
+        <Pointer>
+          <DocumentSectionCode>42A</DocumentSectionCode>
+        </Pointer>
+        <Pointer>
+          <DocumentSectionCode>67A</DocumentSectionCode>
+        </Pointer>
+        <Pointer>
+          <SequenceNumeric>1</SequenceNumeric>
+          <DocumentSectionCode>68A</DocumentSectionCode>
+        </Pointer>
+        <Pointer>
+          <DocumentSectionCode>70A</DocumentSectionCode>
+          <TagID>166</TagID>
+        </Pointer>
+      </Error>
+      <Declaration>
+        <FunctionalReferenceID>NotificationTest</FunctionalReferenceID>
+        <ID>{mrn}</ID>
+        <RejectionDateTime>
+          <DateTimeString formatCode="304">20190328092916Z</DateTimeString>
+        </RejectionDateTime>
+        <VersionID>1</VersionID>
+      </Declaration>
+    </Response>
+  </MetaData>
+
   val validHeaders: Map[String, String] = Map(
     "X-CDS-Client-ID" -> "1234",
     CustomsHeaderNames.XConversationIdName -> "XConv1",
@@ -61,11 +118,11 @@ trait NotificationTestData {
   )
 
   val noAcceptHeader: Map[String, String] = Map(
-    "X-CDS-Client-ID" -> "1234",
-    "X-Conversation-ID" -> "XConv1",
-    HeaderNames.ACCEPT -> "",
-    HeaderNames.CONTENT_TYPE -> ContentTypes.XML(Codec.utf_8),
-    "X-Badge-Identifier" -> "badgeIdentifier1"
+  "X-CDS-Client-ID" -> "1234",
+  "X-Conversation-ID" -> "XConv1",
+  HeaderNames.ACCEPT -> "",
+  HeaderNames.CONTENT_TYPE -> ContentTypes.XML(Codec.utf_8),
+  "X-Badge-Identifier" -> "badgeIdentifier1"
   )
 
   val noContentTypeHeader: Map[String, String] = Map(
@@ -77,5 +134,5 @@ trait NotificationTestData {
   )
 
   val submissionNotification =
-    DeclarationNotification(conversationId = "1234", eori = "eori", mrn = "mrn", metadata = DeclarationMetadata())
-}
+  DeclarationNotification(conversationId = "1234", eori = "eori", mrn = "mrn", metadata = DeclarationMetadata())
+  }

--- a/test/uk/gov/hmrc/exports/repositories/MovementNotificationsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/exports/repositories/MovementNotificationsRepositorySpec.scala
@@ -43,7 +43,7 @@ class MovementNotificationsRepositorySpec extends CustomsExportsBaseSpec with Ex
       found.head.eori must be(eori)
       found.head.conversationId must be(conversationId)
 
-      found.head.dateTimeReceived must be(now)
+      found.head.dateTimeReceived.compareTo(now) must be(0)
 
       // we can also retrieve the submission individually by conversation Id
       val got = repo.getByConversationId(conversationId).futureValue.get

--- a/test/uk/gov/hmrc/exports/repositories/NotificationsRepositorySpec.scala
+++ b/test/uk/gov/hmrc/exports/repositories/NotificationsRepositorySpec.scala
@@ -45,7 +45,7 @@ class NotificationsRepositorySpec extends CustomsExportsBaseSpec with ExportsTes
       found.head.eori must be(eori)
       found.head.conversationId must be(conversationId)
 
-      found.head.dateTimeReceived must be(now)
+      found.head.dateTimeReceived.compareTo(now) must be(0)
 
       // we can also retrieve the submission individually by conversation Id
       val got = repo.getByConversationId(conversationId).futureValue.head


### PR DESCRIPTION
… example of xml response

MRN was being parsed from the incorrect declaration in Metdata. We need to use the one inside response.declaration