### PR TITLE
CEDS-1330: remove the unique key on notification datetime

### DIFF
--- a/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
@@ -37,7 +37,7 @@ class NotificationRepository @Inject()(mc: ReactiveMongoComponent)(implicit ec: 
     ) {
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq("dateTimeIssued" -> IndexType.Ascending), unique = true, name = Some("dateTimeIssuedIdx")),
+    Index(Seq("dateTimeIssued" -> IndexType.Ascending), name = Some("dateTimeIssuedIdx")),
     Index(Seq("mrn" -> IndexType.Ascending), name = Some("mrnIdx")),
     Index(Seq("conversationId" -> IndexType.Ascending), name = Some("conversationIdIdx"))
   )


### PR DESCRIPTION
This was breaking notifications in DEV