### PR TITLE
CEDS-1219 Upgrade for libraries and get rid of hmrctest

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
   private val testScope = "test,it"
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.19.0-play-26",
+    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.20.0-play-26",
     ws,
     "uk.gov.hmrc" %% "bootstrap-play-26" % "0.39.0",
     "uk.gov.hmrc" %% "wco-dec" % "0.30.0",
@@ -17,7 +17,6 @@ object AppDependencies {
   )
 
   def test(scope: String = "test") = Seq(
-    "uk.gov.hmrc" %% "hmrctest" % "3.8.0-play-26" % testScope,
     "org.scalatest" %% "scalatest" % "3.0.5" % testScope,
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test",
     "com.github.tomakehurst" % "wiremock" % wireMockVersion % testScope exclude("org.apache.httpcomponents","httpclient") exclude("org.apache.httpcomponents","httpcore"),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "1.16.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "1.19.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "1.6.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "0.19.0")
 

--- a/test/integration/uk/gov/hmrc/exports/base/IntegrationTestSpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/base/IntegrationTestSpec.scala
@@ -21,7 +21,7 @@ import com.google.inject.AbstractModule
 import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import play.api.inject.guice.GuiceableModule
-import uk.gov.hmrc.play.test.UnitSpec
+import unit.uk.gov.hmrc.exports.base.UnitSpec
 
 object IntegrationTestModule extends AbstractModule {
   def configure(): Unit = ()

--- a/test/unit/uk/gov/hmrc/exports/base/UnitSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/UnitSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.uk.gov.hmrc.exports.base
+
+import java.nio.charset.Charset
+
+import akka.stream.Materializer
+import akka.util.ByteString
+import org.scalatest.{Matchers, OptionValues, WordSpecLike}
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Result
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.language.implicitConversions
+
+trait UnitSpec extends WordSpecLike with Matchers with OptionValues {
+
+  import scala.concurrent.duration._
+  import scala.concurrent.{Await, Future}
+
+  implicit val defaultTimeout: FiniteDuration = 5 seconds
+
+  implicit def extractAwait[A](future: Future[A]): A = await[A](future)
+
+  def await[A](future: Future[A])(implicit timeout: Duration): A = Await.result(future, timeout)
+
+  // Convenience to avoid having to wrap andThen() parameters in Future.successful
+  implicit def liftFuture[A](v: A): Future[A] = Future.successful(v)
+
+  def status(of: Result): Int = of.header.status
+
+  def status(of: Future[Result])(implicit timeout: Duration): Int = status(Await.result(of, timeout))
+
+  def jsonBodyOf(result: Result)(implicit mat: Materializer): JsValue = {
+    Json.parse(bodyOf(result))
+  }
+
+  def jsonBodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[JsValue] = {
+    resultF.map(jsonBodyOf)
+  }
+
+  def bodyOf(result: Result)(implicit mat: Materializer): String = {
+    val bodyBytes: ByteString = await(result.body.consumeData)
+    // We use the default charset to preserve the behaviour of a previous
+    // version of this code, which used new String(Array[Byte]).
+    // If the fact that the previous version used the default charset was an
+    // accident then it may be better to decode in UTF-8 or the charset
+    // specified by the result's headers.
+    bodyBytes.decodeString(Charset.defaultCharset().name)
+  }
+
+  def bodyOf(resultF: Future[Result])(implicit mat: Materializer): Future[String] = {
+    resultF.map(bodyOf)
+  }
+}

--- a/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
@@ -19,15 +19,14 @@ package unit.uk.gov.hmrc.exports.config
 import java.util.UUID
 
 import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{Matchers, WordSpec}
 import org.scalatest.mockito.MockitoSugar
-import play.api.Mode
 import play.api.Mode.Test
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.play.bootstrap.config.{RunMode, ServicesConfig}
-import uk.gov.hmrc.play.test.UnitSpec
 
-class AppConfigSpec extends UnitSpec with MockitoSugar {
+class AppConfigSpec extends WordSpec with Matchers with MockitoSugar {
   private val validAppConfig: Config =
     ConfigFactory.parseString("""
       |urls.login="http://localhost:9949/auth-login-stub/gg-sign-in"

--- a/test/unit/uk/gov/hmrc/exports/connectors/CustomsDeclarationsConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/connectors/CustomsDeclarationsConnectorSpec.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
 import uk.gov.hmrc.exports.models.CustomsDeclarationsResponse
 import uk.gov.hmrc.http._
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
-import uk.gov.hmrc.play.test.UnitSpec
+import unit.uk.gov.hmrc.exports.base.UnitSpec
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global


### PR DESCRIPTION
PR cover upgrade libraries and removing deprecated hmrctest.
One class from this library is added to our codebase (UnitSpec) because a lot of tests are based on this.