### PR TITLE
CEDS-1475 Make DUCR mandatory and personal UCR optional

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/ConsignmentReferences.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ConsignmentReferences.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.exports.models.declaration
 
 import play.api.libs.json.{Json, OFormat}
 
-case class ConsignmentReferences(ducr: Option[DUCR], lrn: String)
+case class ConsignmentReferences(ducr: DUCR, lrn: String, personalUcr: Option[String] = None)
 
 object ConsignmentReferences {
   implicit val format: OFormat[ConsignmentReferences] = Json.format[ConsignmentReferences]

--- a/app/uk/gov/hmrc/exports/models/declaration/DUCR.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/DUCR.scala
@@ -18,7 +18,9 @@ package uk.gov.hmrc.exports.models.declaration
 
 import play.api.libs.json.{Json, OFormat}
 
-case class DUCR(ducr: String)
+case class DUCR(ducr: String) {
+  def nonEmpty: Boolean = this.ducr.nonEmpty
+}
 
 object DUCR {
   implicit val format: OFormat[DUCR] = Json.format[DUCR]

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/Submission.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/Submission.scala
@@ -25,7 +25,7 @@ case class Submission(
   eori: String,
   lrn: String,
   mrn: Option[String] = None,
-  ducr: Option[String] = None,
+  ducr: String,
   actions: Seq[Action] = Seq.empty
 )
 

--- a/app/uk/gov/hmrc/exports/services/WcoMapperService.scala
+++ b/app/uk/gov/hmrc/exports/services/WcoMapperService.scala
@@ -28,19 +28,17 @@ class WcoMapperService @Inject()(submissionMetadataBuilder: SubmissionMetaDataBu
   def produceMetaData(exportsCacheModel: ExportsDeclaration): MetaData =
     submissionMetadataBuilder.build(exportsCacheModel)
 
-  def declarationUcr(metaData: MetaData): Option[String] = {
-    val ucr = Option(
+  def declarationDucr(metaData: MetaData): Option[String] =
+    Option(
       metaData.getAny
         .asInstanceOf[JAXBElement[Declaration]]
         .getValue
         .getGoodsShipment
-        .getUCR
-    )
-
-    ucr
-      .map(_.getTraderAssignedReferenceID.getValue)
-      .orElse(Some(""))
-  }
+        .getPreviousDocument
+        .get(0)
+        .getID
+        .getValue
+    ).orElse(None)
 
   def declarationLrn(metaData: MetaData): Option[String] =
     Option(
@@ -49,7 +47,7 @@ class WcoMapperService @Inject()(submissionMetadataBuilder: SubmissionMetaDataBu
         .getValue
         .getFunctionalReferenceID
         .getValue
-    ).orElse(Some(""))
+    ).orElse(None)
 
   def toXml(metaData: MetaData) = {
     import java.io.StringWriter

--- a/app/uk/gov/hmrc/exports/services/WcoSubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/WcoSubmissionService.scala
@@ -33,9 +33,12 @@ class WcoSubmissionService @Inject()(
     declaration: ExportsDeclaration
   )(implicit hc: HeaderCarrier, execution: ExecutionContext): Future[Submission] = {
     val metaData = wcoMapperService.produceMetaData(declaration)
-    val lrn = wcoMapperService.declarationLrn(metaData)
+    val lrn = wcoMapperService
+      .declarationLrn(metaData)
       .getOrElse(throw new IllegalArgumentException("An LRN is required"))
-    val ducr = wcoMapperService.declarationUcr(metaData)
+    val ducr = wcoMapperService
+      .declarationDucr(metaData)
+      .getOrElse(throw new IllegalArgumentException("An DUCR is required"))
     val payload = wcoMapperService.toXml(metaData)
 
     customsDeclarationsConnector.submitDeclaration(declaration.eori, payload) map { conversationId =>

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilder.scala
@@ -59,6 +59,8 @@ class GoodsShipmentBuilder @Inject()(
     exportsCacheModel.locations.warehouseIdentification
       .foreach(warehouseBuilder.buildThenAdd(_, goodsShipment))
 
+    exportsCacheModel.consignmentReferences.foreach(previousDocumentsBuilder.buildThenAdd(_, goodsShipment))
+
     exportsCacheModel.previousDocuments.foreach(previousDocumentsBuilder.buildThenAdd(_, goodsShipment))
 
     exportsCacheModel.parties.declarationAdditionalActorsData.foreach {

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/UCRBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/UCRBuilder.scala
@@ -26,17 +26,17 @@ import wco.datamodel.wco.declaration_ds.dms._2.UCRTraderAssignedReferenceIDType
 class UCRBuilder @Inject()() extends ModifyingBuilder[ConsignmentReferences, GoodsShipment] {
   override def buildThenAdd(model: ConsignmentReferences, goodsShipment: GoodsShipment): Unit =
     if (isDefined(model)) {
-      goodsShipment.setUCR(createUCR(model))
+      goodsShipment.setUCR(createPersonalUCR(model))
     }
 
-  private def isDefined(reference: ConsignmentReferences): Boolean = reference.ducr.isDefined
+  private def isDefined(reference: ConsignmentReferences): Boolean = reference.personalUcr.isDefined
 
-  private def createUCR(data: ConsignmentReferences): UCR = {
+  private def createPersonalUCR(data: ConsignmentReferences): UCR = {
     val ucr = new UCR()
 
-    data.ducr.foreach { value =>
+    data.personalUcr.foreach { personalUcr =>
       val traderAssignedReferenceID = new UCRTraderAssignedReferenceIDType()
-      traderAssignedReferenceID.setValue(value.ducr)
+      traderAssignedReferenceID.setValue(personalUcr)
       ucr.setTraderAssignedReferenceID(traderAssignedReferenceID)
     }
 

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -32,7 +32,11 @@ import uk.gov.hmrc.exports.models.{CustomsDeclarationsResponse, LocalReferenceNu
 import uk.gov.hmrc.exports.repositories.{NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.services.SubmissionService
 import uk.gov.hmrc.http.HeaderCarrier
-import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder.{buildCustomsDeclarationsConnectorMock, buildNotificationRepositoryMock, buildSubmissionRepositoryMock}
+import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder.{
+  buildCustomsDeclarationsConnectorMock,
+  buildNotificationRepositoryMock,
+  buildSubmissionRepositoryMock
+}
 import util.testdata.ExportsTestData._
 import util.testdata.SubmissionTestData._
 
@@ -58,16 +62,20 @@ class SubmissionServiceSpec extends WordSpec with MockitoSugar with ScalaFutures
   "create" should {
     "delegate to the repository" when {
       "no notifications" in new Test {
-        val submission: Submission = Submission(eori = "", lrn = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
+        val submission: Submission =
+          Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
 
         submissionService.create(submission).futureValue mustBe submission
       }
 
       "some notifications" in new Test {
-        val submission: Submission = Submission(eori = "", lrn = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
+        val submission: Submission =
+          Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
         val notification = Notification("conversation-id", "mrn", LocalDateTime.now(), "", None, Seq.empty, "")
-        when(notificationRepositoryMock.findNotificationsByConversationId("conversation-id")).thenReturn(Future.successful(Seq(notification)))
-        when(submissionRepositoryMock.updateMrn("conversation-id", "mrn")).thenReturn(Future.successful(Some(submission)))
+        when(notificationRepositoryMock.findNotificationsByConversationId("conversation-id"))
+          .thenReturn(Future.successful(Seq(notification)))
+        when(submissionRepositoryMock.updateMrn("conversation-id", "mrn"))
+          .thenReturn(Future.successful(Some(submission)))
 
         submissionService.create(submission).futureValue mustBe submission
 
@@ -107,7 +115,8 @@ class SubmissionServiceSpec extends WordSpec with MockitoSugar with ScalaFutures
     }
 
     "return submission returned by SubmissionRepository" in new Test {
-      when(submissionRepositoryMock.findSubmissionByUuid(meq(eori), meq(uuid))).thenReturn(Future.successful(Some(submission)))
+      when(submissionRepositoryMock.findSubmissionByUuid(meq(eori), meq(uuid)))
+        .thenReturn(Future.successful(Some(submission)))
 
       val returnedSubmission = submissionService.getSubmission(eori, uuid).futureValue
 

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/FunctionalReferenceIdentificationBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/FunctionalReferenceIdentificationBuilderSpec.scala
@@ -46,7 +46,7 @@ class FunctionalReferenceIdentificationBuilderSpec extends WordSpec with Matcher
       val builder = new FunctionalReferenceIdBuilder
 
       val declaration = new Declaration
-      val model = aDeclaration(withConsignmentReferences(ducr = None, lrn = ""))
+      val model = aDeclaration(withConsignmentReferences(ducr = "", lrn = ""))
       builder.buildThenAdd(model, declaration)
 
       declaration.getFunctionalReferenceID should be(null)

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
@@ -72,7 +72,7 @@ class GoodsShipmentBuilderSpec extends WordSpec with Matchers with ExportsDeclar
           withGoodsLocation(GoodsLocationBuilderSpec.correctGoodsLocation),
           withDestinationCountries("GB", Seq.empty, "PL"),
           withWarehouseIdentification(WarehouseIdentification(Some("GBWKG001"), Some("R"), None, Some("2"))),
-          withConsignmentReferences(Some("8GB123456789012-1234567890QWERTYUIO"), "123LRN"),
+          withConsignmentReferences("8GB123456789012-1234567890QWERTYUIO", "123LRN", Some("8GB123456789012")),
           withPreviousDocuments(correctPreviousDocument),
           withItem()
         )

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
@@ -28,21 +28,28 @@ class PreviousDocumentsBuilderSpec extends WordSpec with Matchers with MockitoSu
   "PreviousDocumentsBuilder " should {
 
     "correctly map new model to a WCO-DEC GoodsShipment.PreviousDocuments instance" when {
-      "when document data is present" in {
+      "when document data is present and a DUCR has been added previously" in {
 
         val builder = new PreviousDocumentsBuilder
         val goodsShipment = new GoodsShipment
+        builder.buildThenAdd(UCRBuilderSpec.correctConsignmentReferences, goodsShipment)
+
         builder.buildThenAdd(
           PreviousDocuments(Seq(PreviousDocumentsBuilderSpec.correctPreviousDocument)),
           goodsShipment
         )
 
         val previousDocs = goodsShipment.getPreviousDocument
-        previousDocs.size should be(1)
-        previousDocs.get(0).getID.getValue should be("DocumentReference")
-        previousDocs.get(0).getCategoryCode.getValue should be("X")
-        previousDocs.get(0).getTypeCode.getValue should be("ABC")
-        previousDocs.get(0).getLineNumeric should be(BigDecimal(123).bigDecimal)
+        previousDocs.size should be(2)
+        previousDocs.get(0).getID.getValue should be(UCRBuilderSpec.correctConsignmentReferences.ducr.ducr)
+        previousDocs.get(0).getCategoryCode.getValue should be("Z")
+        previousDocs.get(0).getTypeCode.getValue should be("DCR")
+        previousDocs.get(0).getLineNumeric should be(BigDecimal(1).bigDecimal)
+
+        previousDocs.get(1).getID.getValue should be("DocumentReference")
+        previousDocs.get(1).getCategoryCode.getValue should be("X")
+        previousDocs.get(1).getTypeCode.getValue should be("ABC")
+        previousDocs.get(1).getLineNumeric should be(BigDecimal(123).bigDecimal)
 
       }
 

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/UCRBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/UCRBuilderSpec.scala
@@ -26,8 +26,8 @@ class UCRBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
   "UCRBuilder" should {
 
-    "correctly map new model to the WCO-DEC GoodsShipment.UCR instance" when {
-      "ducr supplied" in {
+    "correctly map new model to the WCO-DEC GoodsShipment.UCRBuilder instance" when {
+      "personal UCR supplied" in {
 
         val builder = new UCRBuilder
 
@@ -36,15 +36,15 @@ class UCRBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
         val ucrObject = goodsShipment.getUCR
         ucrObject.getID should be(null)
-        ucrObject.getTraderAssignedReferenceID.getValue should be(UCRBuilderSpec.exemplaryDucr)
+        ucrObject.getTraderAssignedReferenceID.getValue should be(UCRBuilderSpec.exemplaryPersonalUcr)
       }
 
-      "ducr not supplied" in {
+      "personal UCR not supplied" in {
 
         val builder = new UCRBuilder
 
         val goodsShipment = new GoodsShipment
-        builder.buildThenAdd(UCRBuilderSpec.correctConsignmentReferencesNoDucr, goodsShipment)
+        builder.buildThenAdd(UCRBuilderSpec.correctConsignmentReferencesNoPersonalUcr, goodsShipment)
 
         goodsShipment.getUCR should be(null)
       }
@@ -55,6 +55,9 @@ class UCRBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
 object UCRBuilderSpec {
   val exemplaryDucr = "8GB123456789012-1234567890QWERTYUIO"
-  val correctConsignmentReferences = ConsignmentReferences(ducr = Some(DUCR(ducr = exemplaryDucr)), lrn = "123LRN")
-  val correctConsignmentReferencesNoDucr = ConsignmentReferences(ducr = None, lrn = "123LRN")
+  val exemplaryPersonalUcr = "8GB123456789012"
+  val correctConsignmentReferences =
+    ConsignmentReferences(ducr = DUCR(ducr = exemplaryDucr), lrn = "123LRN", personalUcr = Some(exemplaryPersonalUcr))
+  val correctConsignmentReferencesNoPersonalUcr =
+    ConsignmentReferences(ducr = DUCR(ducr = exemplaryDucr), lrn = "123LRN")
 }

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.exports.models.declaration._
 trait ExportsDeclarationBuilder {
 
   private type ExportsDeclarationModifier = ExportsDeclaration => ExportsDeclaration
+  protected val VALID_PERSONAL_UCR = "5GB123456789000"
   protected val VALID_DUCR = "5GB123456789000-123ABC456DEFIIIII"
   protected val VALID_LRN = "FG7676767889"
   private val modelWithDefaults: ExportsDeclaration = ExportsDeclaration(
@@ -77,10 +78,11 @@ trait ExportsDeclarationBuilder {
   def withoutConsignmentReferences(): ExportsDeclarationModifier = _.copy(consignmentReferences = None)
 
   def withConsignmentReferences(
-    ducr: Option[String] = Some(VALID_DUCR),
-    lrn: String = VALID_LRN
+    ducr: String = VALID_DUCR,
+    lrn: String = VALID_LRN,
+    personalUcr: Option[String] = Some(VALID_DUCR)
   ): ExportsDeclarationModifier =
-    _.copy(consignmentReferences = Some(ConsignmentReferences(ducr.map(DUCR(_)), lrn)))
+    _.copy(consignmentReferences = Some(ConsignmentReferences(DUCR(ducr), lrn, personalUcr)))
 
   def withoutBorderTransport(): ExportsDeclarationModifier = _.copy(borderTransport = None)
 

--- a/test/util/testdata/SubmissionTestData.scala
+++ b/test/util/testdata/SubmissionTestData.scala
@@ -24,10 +24,6 @@ import util.testdata.ExportsTestData._
 
 object SubmissionTestData {
 
-  val uuid: String = UUID.randomUUID().toString
-  val uuid_2: String = UUID.randomUUID().toString
-  val uuid_3: String = UUID.randomUUID().toString
-
   lazy val action = Action(requestType = SubmissionRequest, conversationId = conversationId)
   lazy val action_2 = Action(
     requestType = SubmissionRequest,
@@ -44,20 +40,21 @@ object SubmissionTestData {
     conversationId = conversationId,
     requestTimestamp = action.requestTimestamp.plusHours(3)
   )
-
   lazy val submission: Submission =
-    Submission(uuid = uuid, eori = eori, lrn = lrn, mrn = Some(mrn), ducr = Some(ducr), actions = Seq(action))
+    Submission(uuid = uuid, eori = eori, lrn = lrn, mrn = Some(mrn), ducr = ducr, actions = Seq(action))
   lazy val submission_2: Submission =
-    Submission(uuid = uuid_2, eori = eori, lrn = lrn, mrn = Some(mrn_2), ducr = Some(ducr), actions = Seq(action_2))
+    Submission(uuid = uuid_2, eori = eori, lrn = lrn, mrn = Some(mrn_2), ducr = ducr, actions = Seq(action_2))
   lazy val submission_3: Submission =
-    Submission(uuid = uuid_3, eori = eori, lrn = lrn, mrn = Some(mrn_2), ducr = Some(ducr), actions = Seq(action_3))
-
+    Submission(uuid = uuid_3, eori = eori, lrn = lrn, mrn = Some(mrn_2), ducr = ducr, actions = Seq(action_3))
   lazy val cancelledSubmission: Submission = Submission(
     uuid = uuid,
     eori = eori,
     lrn = lrn,
     mrn = Some(mrn),
-    ducr = Some(ducr),
+    ducr = ducr,
     actions = Seq(action, actionCancellation)
   )
+  val uuid: String = UUID.randomUUID().toString
+  val uuid_2: String = UUID.randomUUID().toString
+  val uuid_3: String = UUID.randomUUID().toString
 }


### PR DESCRIPTION
With this change:
 * DUCR will map to the first item of the `GoodsShipment.PreviousDocuments` list
 * LRN stays as is
 * An Optional personal UCR will, if available, will map to the
   `GoodsShipment.UCR.TraderAssignedReferenceID`