### PR TITLE
CEDS-1560  Library upgrade and fixes for deprecated methods

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,25 +4,25 @@ import sbt._
 
 object AppDependencies {
 
-  private val wireMockVersion = "2.23.2"
+  private val wireMockVersion = "2.24.1"
   private val testScope = "test,it"
 
   val compile = Seq(
     "uk.gov.hmrc" %% "simple-reactivemongo" % "7.20.0-play-26",
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "0.39.0",
-    "uk.gov.hmrc" %% "wco-dec" % "0.30.0",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "0.45.0",
+    "uk.gov.hmrc" %% "wco-dec" % "0.31.0",
     "uk.gov.hmrc" %% "logback-json-logger" % "4.6.0",
     "com.typesafe.play" %% "play-json-joda" % "2.6.10"
   )
 
   def test(scope: String = "test") = Seq(
-    "org.scalatest" %% "scalatest" % "3.0.5" % testScope,
+    "org.scalatest" %% "scalatest" % "3.0.8" % testScope,
     "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % "test",
     "com.github.tomakehurst" % "wiremock" % wireMockVersion % testScope exclude("org.apache.httpcomponents","httpclient") exclude("org.apache.httpcomponents","httpcore"),
     "org.pegdown" % "pegdown" % "1.6.0" % testScope,
     "com.typesafe.play" %% "play-test" % PlayVersion.current % testScope,
-    "org.mockito" % "mockito-core" % "2.27.0" % "test"
+    "org.mockito" % "mockito-core" % "3.0.0" % "test"
   )
 
   val jettyVersion = "9.2.26.v20180806"

--- a/test/component/uk/gov/hmrc/exports/base/ComponentTestSpec.scala
+++ b/test/component/uk/gov/hmrc/exports/base/ComponentTestSpec.scala
@@ -25,7 +25,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest._
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.bind

--- a/test/integration/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorSpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorSpec.scala
@@ -18,7 +18,7 @@ package integration.uk.gov.hmrc.exports.connector
 
 import integration.uk.gov.hmrc.exports.base.IntegrationTestSpec
 import integration.uk.gov.hmrc.exports.util.TestModule
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder

--- a/test/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
+++ b/test/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.exports.controllers.request
 
 import java.time.Instant
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration._
 import uk.gov.hmrc.exports.models.{Choice, Eori}

--- a/test/unit/uk/gov/hmrc/exports/base/AuthTestSupport.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/AuthTestSupport.scala
@@ -19,7 +19,7 @@ package unit.uk.gov.hmrc.exports.base
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.{ArgumentMatcher, ArgumentMatchers}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.allEnrolments

--- a/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
@@ -24,7 +24,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application

--- a/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
@@ -20,7 +20,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
 import uk.gov.hmrc.exports.metrics.ExportsMetrics
 import uk.gov.hmrc.exports.models.CustomsDeclarationsResponse

--- a/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 import com.typesafe.config.{Config, ConfigFactory}
 import org.scalatest.{Matchers, WordSpec}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.Mode.Test
 import play.api.{Configuration, Environment}
 import uk.gov.hmrc.exports.config.AppConfig

--- a/test/unit/uk/gov/hmrc/exports/connectors/CustomsDeclarationsConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/connectors/CustomsDeclarationsConnectorSpec.scala
@@ -18,7 +18,7 @@ package unit.uk.gov.hmrc.exports.connectors
 
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import play.api.http.Status
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector

--- a/test/unit/uk/gov/hmrc/exports/controllers/HeaderValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/HeaderValidatorSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.controllers
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import uk.gov.hmrc.exports.controllers.util.HeaderValidator
 import uk.gov.hmrc.exports.models._

--- a/test/unit/uk/gov/hmrc/exports/scheduler/PurgeDraftDeclarationsJobSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/PurgeDraftDeclarationsJobSpec.scala
@@ -21,7 +21,7 @@ import java.time._
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito.{reset, verify}
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.config.{AppConfig, JobConfig}
 import uk.gov.hmrc.exports.repositories.DeclarationRepository
 import uk.gov.hmrc.exports.scheduler.PurgeDraftDeclarationsJob

--- a/test/unit/uk/gov/hmrc/exports/scheduler/SchedulerDateUtilSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/SchedulerDateUtilSpec.scala
@@ -20,7 +20,7 @@ import java.time._
 
 import org.mockito.BDDMockito.given
 import org.scalatest.BeforeAndAfterEach
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.exports.scheduler.SchedulerDateUtil
 import unit.uk.gov.hmrc.exports.base.UnitSpec

--- a/test/unit/uk/gov/hmrc/exports/scheduler/SchedulerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/SchedulerSpec.scala
@@ -27,7 +27,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.exports.scheduler.{ScheduledJob, ScheduledJobs, Scheduler, SchedulerDateUtil}
 import unit.uk.gov.hmrc.exports.base.UnitSpec

--- a/test/unit/uk/gov/hmrc/exports/services/DeclarationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/DeclarationServiceSpec.scala
@@ -20,7 +20,7 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.submissions.Submission
 import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration}

--- a/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentCaptor, InOrder, Mockito}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import reactivemongo.bson.{BSONDocument, BSONInteger, BSONString}
 import reactivemongo.core.errors.DetailedDatabaseException

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -22,7 +22,7 @@ import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito._
 import org.mockito.{ArgumentCaptor, InOrder, Mockito}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.http.Status._
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/AuthorisationHoldersBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/AuthorisationHoldersBuilderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.DeclarationHolder
 import uk.gov.hmrc.exports.services.mapping.AuthorisationHoldersBuilder

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/AgentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/AgentBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.{Address, EntityDetails, RepresentativeDetails}

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/BorderTransportMeansBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/BorderTransportMeansBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.services.CountriesService

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/DeclarantBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/DeclarantBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.Address

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExporterBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExporterBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.Address

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilderSpec.scala
@@ -18,7 +18,7 @@ package unit.uk.gov.hmrc.exports.services.mapping.declaration.consignment
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Choice
 import uk.gov.hmrc.exports.services.mapping.declaration.consignment.{

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/AEOMutualRecognitionPartiesBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/AEOMutualRecognitionPartiesBuilderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.PartyType.{Consolidator, FreightForwarder}
 import uk.gov.hmrc.exports.models.declaration.{DeclarationAdditionalActor, DeclarationAdditionalActors}

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/ConsigneeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/ConsigneeBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.{Address, ConsigneeDetails, EntityDetails}

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/DestinationBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/DestinationBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.DestinationCountries

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/ExportCountryBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/ExportCountryBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.DestinationCountries

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
@@ -18,7 +18,7 @@ package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
 import org.mockito.ArgumentMatchers.{any, refEq}
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration._
 import uk.gov.hmrc.exports.services.mapping.goodsshipment._

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.{PreviousDocument, PreviousDocuments}
 import uk.gov.hmrc.exports.services.mapping.goodsshipment.PreviousDocumentsBuilder

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/UCRBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/UCRBuilderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.{ConsignmentReferences, DUCR}
 import uk.gov.hmrc.exports.services.mapping.goodsshipment.UCRBuilder

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.WarehouseIdentification
 import uk.gov.hmrc.exports.services.mapping.goodsshipment.WarehouseBuilder

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
@@ -18,7 +18,7 @@ package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment
 
 import org.mockito.ArgumentMatchers.{any, refEq}
 import org.mockito.Mockito.verify
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Choice
 import uk.gov.hmrc.exports.models.declaration.{BorderTransport, ExportsDeclaration, Seal, TransportDetails}

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentCarrierBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentCarrierBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.{Choice, Country}
 import uk.gov.hmrc.exports.models.declaration.Address

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/GoodsLocationBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/GoodsLocationBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment
 
 import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.GoodsLocation

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
 
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.AdditionalInformation
 import uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem.AdditionalInformationBuilder

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
@@ -18,7 +18,7 @@ package unit.uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import play.api.libs.json._
 import uk.gov.hmrc.exports.models.declaration._


### PR DESCRIPTION
Upgrade libraries to the newest possible version for us.

MockitoSugar is moved to different package, changed imports to don't have deprecated warnings.

Below deprecated method form MockitoSugar
`
@deprecated("MockitoSugar has been moved from org.scalatest.mockito to org.scalatestplus.mockito. Please update your imports, as this deprecated type alias will be removed in a future version of ScalaTest.")
`