### PR TITLE
CEDS-1622 Remove MRN dependency for Notifications

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
@@ -51,9 +51,9 @@ class NotificationController @Inject()(
 
   def findByID(id: String): Action[AnyContent] = authorisedAction(bodyParsers.default) { implicit request =>
     submissionService.getSubmission(request.eori.value, id) flatMap {
-      case Some(submission) if submission.mrn.isDefined =>
+      case Some(submission) =>
         notificationsService
-          .getNotificationsForSubmission(submission.mrn.get)
+          .getNotifications(submission)
           .map(notifications => Ok(notifications))
       case _ => Future.successful(NotFound)
     }

--- a/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
@@ -78,7 +78,7 @@ object UnitTestMockBuilder extends MockitoSugar {
   def buildNotificationServiceMock: NotificationService = {
     val notificationServiceMock: NotificationService = mock[NotificationService]
     when(notificationServiceMock.getAllNotificationsForUser(any())).thenReturn(Future.successful(Seq.empty))
-    when(notificationServiceMock.getNotificationsForSubmission(any())).thenReturn(Future.successful(Seq.empty))
+    when(notificationServiceMock.getNotifications(any())).thenReturn(Future.successful(Seq.empty))
     when(notificationServiceMock.saveAll(any())).thenReturn(Future.successful(Left("")))
     when(notificationServiceMock.save(any())).thenReturn(Future.successful(Left("")))
     notificationServiceMock

--- a/test/unit/uk/gov/hmrc/exports/controllers/NotificationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/NotificationControllerSpec.scala
@@ -76,7 +76,7 @@ class NotificationControllerSpec
       "submission found" in {
         withAuthorizedUser()
         when(submissionService.getSubmission(any(), any())).thenReturn(Future.successful(Some(submission)))
-        when(notificationServiceMock.getNotificationsForSubmission(any()))
+        when(notificationServiceMock.getNotifications(any()))
           .thenReturn(Future.successful(Seq(notification)))
 
         val result = route(app, FakeRequest("GET", "/v2/declarations/1234/submission/notifications")).get


### PR DESCRIPTION
We have a technical debt ticket to link notifications to submissions/declarations by declaration ID.

At first we suggested adding the declaration ID to each notification but I'm not sure this is completely necessary. I think the "conversation ID" acts as an "Action ID". We can simplify the look up by using this instead.

Whilst I'd prefer if we created the "action ID" ourselves I think its fine for now