### PR TITLE
CEDS-1691 - rename fields in Notification

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
@@ -30,6 +30,7 @@ import uk.gov.hmrc.exports.metrics.ExportsMetrics
 import uk.gov.hmrc.exports.metrics.MetricIdentifiers._
 import uk.gov.hmrc.exports.models._
 import uk.gov.hmrc.exports.models.declaration.notifications.{ErrorPointer, Notification, NotificationError}
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
 import uk.gov.hmrc.exports.services.{NotificationService, SubmissionService}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -110,10 +111,12 @@ class NotificationController @Inject()(
 
         Notification(
           conversationId = notificationApiRequestHeaders.conversationId.value,
+          actionId = notificationApiRequestHeaders.conversationId.value,
           mrn = mrn,
           dateTimeIssued = dateTimeIssued,
           functionCode = functionCode,
           nameCode = nameCode,
+          status = SubmissionStatus.retrieve(functionCode, nameCode),
           errors = errors,
           payload = notificationXml.toString
         )

--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
@@ -18,18 +18,21 @@ package uk.gov.hmrc.exports.models.declaration.notifications
 
 import java.time.LocalDateTime
 
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.SubmissionStatus
 
 case class Notification(
   conversationId: String,
+  actionId: String,
   mrn: String,
   dateTimeIssued: LocalDateTime,
   functionCode: String,
   nameCode: Option[String],
+  status: SubmissionStatus,
   errors: Seq[NotificationError],
   payload: String
 )
 
 object Notification {
-  implicit val format = Json.format[Notification]
+  implicit val format: OFormat[Notification] = Json.format[Notification]
 }

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/SubmissionStatus.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/SubmissionStatus.scala
@@ -15,142 +15,43 @@
  */
 
 package uk.gov.hmrc.exports.models.declaration.submissions
+import play.api.libs.json.Format
+import uk.gov.hmrc.exports.util.EnumJson
 
-import play.api.libs.json._
-import uk.gov.hmrc.wco.dec.Response
+object SubmissionStatus extends Enumeration {
+  type SubmissionStatus = Value
+  implicit val format: Format[SubmissionStatus.Value] = EnumJson.format(SubmissionStatus)
+  val PENDING, REQUESTED_CANCELLATION, ACCEPTED, RECEIVED, REJECTED, UNDERGOING_PHYSICAL_CHECK,
+  ADDITIONAL_DOCUMENTS_REQUIRED, AMENDED, RELEASED, CLEARED, CANCELLED, CUSTOMS_POSITION_GRANTED,
+  CUSTOMS_POSITION_DENIED, GOODS_HAVE_EXITED_THE_COMMUNITY, DECLARATION_HANDLED_EXTERNALLY, AWAITING_EXIT_RESULTS,
+  UNKNOWN = Value
 
-sealed trait SubmissionStatus {
-  val fullCode: String
-}
-
-object SubmissionStatus {
-
-  implicit object StatusFormat extends Format[SubmissionStatus] {
-    def reads(status: JsValue): JsResult[SubmissionStatus] = status match {
-      case JsString(code) => JsSuccess(getStatusOrUnknown(code))
-      case _              => JsSuccess(UnknownStatus)
-    }
-
-    def writes(status: SubmissionStatus): JsValue = JsString(status.fullCode)
-  }
-
-  def retrieveFromResponse(response: Response): SubmissionStatus = {
-    val searchKey = response.functionCode + response.status.headOption.flatMap(_.nameCode).getOrElse("")
-    getStatusOrUnknown(searchKey)
-  }
-
-  def retrieve(functionCode: String, nameCode: Option[String]): SubmissionStatus =
+  def retrieve(functionCode: String, nameCode: Option[String] = None): SubmissionStatus =
     getStatusOrUnknown(functionCode + nameCode.getOrElse(""))
 
   private def getStatusOrUnknown(searchKey: String): SubmissionStatus =
     codesMap.get(searchKey) match {
       case Some(status) => status
-      case None         => UnknownStatus
+      case None         => UNKNOWN
     }
 
   private val codesMap: Map[String, SubmissionStatus] = Map(
-    Pending.fullCode -> Pending,
-    RequestedCancellation.fullCode -> RequestedCancellation,
-    Accepted.fullCode -> Accepted,
-    Received.fullCode -> Received,
-    Rejected.fullCode -> Rejected,
-    UndergoingPhysicalCheck.fullCode -> UndergoingPhysicalCheck,
-    AdditionalDocumentsRequired.fullCode -> AdditionalDocumentsRequired,
-    Amended.fullCode -> Amended,
-    Released.fullCode -> Released,
-    Cleared.fullCode -> Cleared,
-    Cancelled.fullCode -> Cancelled,
-    CustomsPositionGranted.fullCode -> CustomsPositionGranted,
-    CustomsPositionDenied.fullCode -> CustomsPositionDenied,
-    GoodsHaveExitedTheCommunity.fullCode -> GoodsHaveExitedTheCommunity,
-    DeclarationHandledExternally.fullCode -> DeclarationHandledExternally,
-    AwaitingExitResults.fullCode -> AwaitingExitResults,
-    UnknownStatus.fullCode -> UnknownStatus
+    "Pending" -> PENDING,
+    "Cancellation Requested" -> REQUESTED_CANCELLATION,
+    "01" -> ACCEPTED,
+    "02" -> RECEIVED,
+    "03" -> REJECTED,
+    "05" -> UNDERGOING_PHYSICAL_CHECK,
+    "06" -> ADDITIONAL_DOCUMENTS_REQUIRED,
+    "07" -> AMENDED,
+    "08" -> RELEASED,
+    "09" -> CLEARED,
+    "10" -> CANCELLED,
+    "1139" -> CUSTOMS_POSITION_GRANTED,
+    "1141" -> CUSTOMS_POSITION_DENIED,
+    "16" -> GOODS_HAVE_EXITED_THE_COMMUNITY,
+    "17" -> DECLARATION_HANDLED_EXTERNALLY,
+    "18" -> AWAITING_EXIT_RESULTS,
+    "UnknownStatus" -> UNKNOWN
   )
-}
-
-case object Pending extends SubmissionStatus {
-  val fullCode: String = "Pending"
-}
-
-case object RequestedCancellation extends SubmissionStatus {
-  val fullCode: String = "Cancellation Requested"
-
-  override def toString: String = "Cancellation Requested"
-}
-
-case object Accepted extends SubmissionStatus {
-  val fullCode: String = "01"
-}
-
-case object Received extends SubmissionStatus {
-  val fullCode: String = "02"
-}
-
-case object Rejected extends SubmissionStatus {
-  val fullCode: String = "03"
-}
-
-case object UndergoingPhysicalCheck extends SubmissionStatus {
-  val fullCode: String = "05"
-
-  override def toString(): String = "Undergoing Physical Check"
-}
-
-case object AdditionalDocumentsRequired extends SubmissionStatus {
-  val fullCode: String = "06"
-
-  override def toString(): String = "Additional Documents Required"
-}
-
-case object Amended extends SubmissionStatus {
-  val fullCode: String = "07"
-}
-
-case object Released extends SubmissionStatus {
-  val fullCode: String = "08"
-}
-
-case object Cleared extends SubmissionStatus {
-  val fullCode: String = "09"
-}
-
-case object Cancelled extends SubmissionStatus {
-  val fullCode: String = "10"
-}
-
-case object CustomsPositionGranted extends SubmissionStatus {
-  val fullCode: String = "1139"
-
-  override def toString(): String = "Customs Position Granted"
-}
-
-case object CustomsPositionDenied extends SubmissionStatus {
-  val fullCode: String = "1141"
-
-  override def toString(): String = "Customs Position Denied"
-}
-
-case object GoodsHaveExitedTheCommunity extends SubmissionStatus {
-  val fullCode: String = "16"
-
-  override def toString(): String = "Goods Have Exited The Community"
-}
-
-case object DeclarationHandledExternally extends SubmissionStatus {
-  val fullCode: String = "17"
-
-  override def toString(): String = "Declaration Handled Externally"
-}
-
-case object AwaitingExitResults extends SubmissionStatus {
-  val fullCode: String = "18"
-
-  override def toString(): String = "Awaiting Exit Results"
-}
-
-case object UnknownStatus extends SubmissionStatus {
-  val fullCode: String = "UnknownStatus"
-
-  override def toString(): String = "Unknown status"
 }

--- a/test/component/uk/gov/hmrc/exports/base/ComponentTestSpec.scala
+++ b/test/component/uk/gov/hmrc/exports/base/ComponentTestSpec.scala
@@ -33,6 +33,7 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.exports.models.declaration.ExportsDeclaration
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.models.declaration.submissions.Submission
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.UNKNOWN
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.http.InternalServerException
 import util._
@@ -98,7 +99,9 @@ trait ComponentTestSpec
 
   def withNotificationRepositorySuccess(): Unit =
     when(mockNotificationsRepository.findNotificationsByConversationId(any())).thenReturn(
-      Future.successful(Seq(Notification("conversation-id", "mrn", LocalDateTime.now(), "", None, Seq.empty, "")))
+      Future.successful(
+        Seq(Notification("conversation-id", "action-id", "mrn", LocalDateTime.now(), "", None, UNKNOWN, Seq.empty, ""))
+      )
     )
 
   def verifySubmissionRepositoryIsCorrectlyCalled(eoriValue: String) {

--- a/test/unit/uk/gov/hmrc/exports/models/declaration/submissions/SubmissionStatusSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/models/declaration/submissions/SubmissionStatusSpec.scala
@@ -17,160 +17,32 @@
 package unit.uk.gov.hmrc.exports.models.declaration.submissions
 
 import org.scalatest.{MustMatchers, WordSpec}
-import play.api.libs.json._
-import uk.gov.hmrc.exports.models.declaration.submissions._
-import uk.gov.hmrc.wco.dec.{Response, ResponseStatus}
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.retrieve
 
 class SubmissionStatusSpec extends WordSpec with MustMatchers {
 
   "Reads for status" should {
-    "correctly read a value for every scenario" in {
-      SubmissionStatus.StatusFormat.reads(JsString("Pending")) must be(JsSuccess(Pending))
-      SubmissionStatus.StatusFormat.reads(JsString("Cancellation Requested")) must be(JsSuccess(RequestedCancellation))
-      SubmissionStatus.StatusFormat.reads(JsString("01")) must be(JsSuccess(Accepted))
-      SubmissionStatus.StatusFormat.reads(JsString("02")) must be(JsSuccess(Received))
-      SubmissionStatus.StatusFormat.reads(JsString("03")) must be(JsSuccess(Rejected))
-      SubmissionStatus.StatusFormat.reads(JsString("05")) must be(JsSuccess(UndergoingPhysicalCheck))
-      SubmissionStatus.StatusFormat.reads(JsString("06")) must be(JsSuccess(AdditionalDocumentsRequired))
-      SubmissionStatus.StatusFormat.reads(JsString("07")) must be(JsSuccess(Amended))
-      SubmissionStatus.StatusFormat.reads(JsString("08")) must be(JsSuccess(Released))
-      SubmissionStatus.StatusFormat.reads(JsString("09")) must be(JsSuccess(Cleared))
-      SubmissionStatus.StatusFormat.reads(JsString("10")) must be(JsSuccess(Cancelled))
-      SubmissionStatus.StatusFormat.reads(JsString("1139")) must be(JsSuccess(CustomsPositionGranted))
-      SubmissionStatus.StatusFormat.reads(JsString("1141")) must be(JsSuccess(CustomsPositionDenied))
-      SubmissionStatus.StatusFormat.reads(JsString("16")) must be(JsSuccess(GoodsHaveExitedTheCommunity))
-      SubmissionStatus.StatusFormat.reads(JsString("17")) must be(JsSuccess(DeclarationHandledExternally))
-      SubmissionStatus.StatusFormat.reads(JsString("18")) must be(JsSuccess(AwaitingExitResults))
-      SubmissionStatus.StatusFormat.reads(JsString("WrongStatus")) must be(JsSuccess(UnknownStatus))
-      SubmissionStatus.StatusFormat.reads(JsString("UnknownStatus")) must be(JsSuccess(UnknownStatus))
-    }
+    "correctly retrieve a value for every scenario" in {
 
-    "correctly write a value for every scenario" in {
-      Json.toJson(Pending) must be(JsString("Pending"))
-      Json.toJson(RequestedCancellation) must be(JsString("Cancellation Requested"))
-      Json.toJson(Accepted) must be(JsString("01"))
-      Json.toJson(Received) must be(JsString("02"))
-      Json.toJson(Rejected) must be(JsString("03"))
-      Json.toJson(UndergoingPhysicalCheck) must be(JsString("05"))
-      Json.toJson(AdditionalDocumentsRequired) must be(JsString("06"))
-      Json.toJson(Amended) must be(JsString("07"))
-      Json.toJson(Released) must be(JsString("08"))
-      Json.toJson(Cleared) must be(JsString("09"))
-      Json.toJson(Cancelled) must be(JsString("10"))
-      Json.toJson(CustomsPositionGranted) must be(JsString("1139"))
-      Json.toJson(CustomsPositionDenied) must be(JsString("1141"))
-      Json.toJson(GoodsHaveExitedTheCommunity) must be(JsString("16"))
-      Json.toJson(DeclarationHandledExternally) must be(JsString("17"))
-      Json.toJson(AwaitingExitResults) must be(JsString("18"))
-      Json.toJson(UnknownStatus) must be(JsString("UnknownStatus"))
-    }
-  }
-
-  "Retrieve from Response method" should {
-    "correctly retrieve Accepted status" in {
-      val acceptedResponse = Response("01")
-
-      SubmissionStatus.retrieveFromResponse(acceptedResponse) must be(Accepted)
-    }
-
-    "correctly retrieve Received status" in {
-      val receivedResponse = Response("02")
-
-      SubmissionStatus.retrieveFromResponse(receivedResponse) must be(Received)
-    }
-
-    "correctly retrieve Rejected status" in {
-      val rejectedResponse = Response("03")
-
-      SubmissionStatus.retrieveFromResponse(rejectedResponse) must be(Rejected)
-    }
-
-    "correctly retrieve UndergoingPhysicalCheck status" in {
-      val undergoingPhysicalCheckResponse = Response("05")
-
-      SubmissionStatus.retrieveFromResponse(undergoingPhysicalCheckResponse) must be(UndergoingPhysicalCheck)
-    }
-
-    "correctly retrieve AdditionalDocumentsRequired status" in {
-      val additionalDocumentsRequiredResponse = Response("06")
-
-      SubmissionStatus.retrieveFromResponse(additionalDocumentsRequiredResponse) must be(AdditionalDocumentsRequired)
-    }
-
-    "correctly retrieve Amended status" in {
-      val amendedResponse = Response("07")
-
-      SubmissionStatus.retrieveFromResponse(amendedResponse) must be(Amended)
-    }
-
-    "correctly retrieve Released status" in {
-      val releasedResponse = Response("08")
-
-      SubmissionStatus.retrieveFromResponse(releasedResponse) must be(Released)
-    }
-
-    "correctly retrieve Cleared status" in {
-      val clearedResponse = Response("09")
-
-      SubmissionStatus.retrieveFromResponse(clearedResponse) must be(Cleared)
-    }
-
-    "correctly retrieve Cancelled status" in {
-      val cancelledResponse = Response("10")
-
-      SubmissionStatus.retrieveFromResponse(cancelledResponse) must be(Cancelled)
-    }
-
-    "correctly retrieve CustomsPositionGranted status" in {
-      val customsPositionGrantedResponse =
-        Response(functionCode = "11", status = Seq(ResponseStatus(nameCode = Some("39"))))
-
-      SubmissionStatus.retrieveFromResponse(customsPositionGrantedResponse) must be(CustomsPositionGranted)
-    }
-
-    "correctly retrieve CustomsPositionDenied status" in {
-      val customsPositionDeniedResponse =
-        Response(functionCode = "11", status = Seq(ResponseStatus(nameCode = Some("41"))))
-
-      SubmissionStatus.retrieveFromResponse(customsPositionDeniedResponse) must be(CustomsPositionDenied)
-    }
-
-    "correctly retrieve GoodsHaveExitedTheCommunity status" in {
-      val goodsHaveExitedTheCommunityResponse = Response("16")
-
-      SubmissionStatus.retrieveFromResponse(goodsHaveExitedTheCommunityResponse) must be(GoodsHaveExitedTheCommunity)
-    }
-
-    "correctly retrieve DeclarationHandledExternally status" in {
-      val declarationHandledExternallyResponse = Response("17")
-
-      SubmissionStatus.retrieveFromResponse(declarationHandledExternallyResponse) must be(DeclarationHandledExternally)
-    }
-
-    "correctly retrieve AwaitingExitResults status" in {
-      val awaitingExitResultsResponse = Response("18")
-
-      SubmissionStatus.retrieveFromResponse(awaitingExitResultsResponse) must be(AwaitingExitResults)
-    }
-
-    "correctly retrieve UnknownStatus status" in {
-      val unknownStatusResponse = Response("20")
-
-      SubmissionStatus.retrieveFromResponse(unknownStatusResponse) must be(UnknownStatus)
-    }
-  }
-
-  "Exports Statuses" should {
-    "return a correct status as String" in {
-      UndergoingPhysicalCheck.toString must be("Undergoing Physical Check")
-      AdditionalDocumentsRequired.toString must be("Additional Documents Required")
-      RequestedCancellation.toString must be("Cancellation Requested")
-      CustomsPositionGranted.toString must be("Customs Position Granted")
-      CustomsPositionDenied.toString must be("Customs Position Denied")
-      GoodsHaveExitedTheCommunity.toString must be("Goods Have Exited The Community")
-      DeclarationHandledExternally.toString must be("Declaration Handled Externally")
-      AwaitingExitResults.toString must be("Awaiting Exit Results")
-      UnknownStatus.toString must be("Unknown status")
+      retrieve("Pending") must be(SubmissionStatus.PENDING)
+      retrieve("Cancellation Requested") must be(SubmissionStatus.REQUESTED_CANCELLATION)
+      retrieve("01") must be(SubmissionStatus.ACCEPTED)
+      retrieve("02") must be(SubmissionStatus.RECEIVED)
+      retrieve("03") must be(SubmissionStatus.REJECTED)
+      retrieve("05") must be(SubmissionStatus.UNDERGOING_PHYSICAL_CHECK)
+      retrieve("06") must be(SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED)
+      retrieve("07") must be(SubmissionStatus.AMENDED)
+      retrieve("08") must be(SubmissionStatus.RELEASED)
+      retrieve("09") must be(SubmissionStatus.CLEARED)
+      retrieve("10") must be(SubmissionStatus.CANCELLED)
+      retrieve("1139") must be(SubmissionStatus.CUSTOMS_POSITION_GRANTED)
+      retrieve("1141") must be(SubmissionStatus.CUSTOMS_POSITION_DENIED)
+      retrieve("16") must be(SubmissionStatus.GOODS_HAVE_EXITED_THE_COMMUNITY)
+      retrieve("17") must be(SubmissionStatus.DECLARATION_HANDLED_EXTERNALLY)
+      retrieve("18") must be(SubmissionStatus.AWAITING_EXIT_RESULTS)
+      retrieve("UnknownStatus") must be(SubmissionStatus.UNKNOWN)
+      retrieve("WrongStatus") must be(SubmissionStatus.UNKNOWN)
     }
   }
 }

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -25,8 +25,8 @@ import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
-import uk.gov.hmrc.exports.models.declaration.submissions._
-import uk.gov.hmrc.exports.models.{Eori, LocalReferenceNumber, SubmissionRequestHeaders}
+import uk.gov.hmrc.exports.models.declaration.submissions.{SubmissionStatus, _}
+import uk.gov.hmrc.exports.models.{LocalReferenceNumber, SubmissionRequestHeaders}
 import uk.gov.hmrc.exports.repositories.{NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.services.mapping.MetaDataBuilder
 import uk.gov.hmrc.exports.services.{SubmissionService, WcoMapperService}
@@ -113,7 +113,17 @@ class SubmissionServiceSpec extends WordSpec with MockitoSugar with ScalaFutures
       "some notifications" in new Test {
         val submission: Submission =
           Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
-        val notification = Notification("conversation-id", "mrn", LocalDateTime.now(), "", None, Seq.empty, "")
+        val notification = Notification(
+          "conversation-id",
+          "action-id",
+          "mrn",
+          LocalDateTime.now(),
+          "",
+          None,
+          status = SubmissionStatus.UNKNOWN,
+          Seq.empty,
+          ""
+        )
         when(notificationRepositoryMock.findNotificationsByConversationId("conversation-id"))
           .thenReturn(Future.successful(Seq(notification)))
         when(submissionRepositoryMock.updateMrn("conversation-id", "mrn"))

--- a/test/util/testdata/NotificationTestData.scala
+++ b/test/util/testdata/NotificationTestData.scala
@@ -23,6 +23,7 @@ import play.api.http.{ContentTypes, HeaderNames}
 import play.api.mvc.Codec
 import uk.gov.hmrc.exports.controllers.util.CustomsHeaderNames
 import uk.gov.hmrc.exports.models.declaration.notifications.{ErrorPointer, Notification, NotificationError}
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
 import util.testdata.ExportsTestData._
 
 import scala.util.Random
@@ -252,28 +253,34 @@ object NotificationTestData {
 
   val notification = Notification(
     conversationId = conversationId,
+    actionId = conversationId,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued,
     functionCode = functionCode,
     nameCode = nameCode,
+    status = SubmissionStatus.UNKNOWN,
     errors = errors,
     payload = payload
   )
   val notification_2 = Notification(
     conversationId = conversationId,
+    actionId = conversationId,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued_2,
     functionCode = functionCode_2,
     nameCode = nameCode,
+    status = SubmissionStatus.UNKNOWN,
     errors = errors,
     payload = payload_2
   )
   val notification_3 = Notification(
     conversationId = conversationId_2,
+    actionId = conversationId_2,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued_3,
     functionCode = functionCode_3,
     nameCode = nameCode,
+    status = SubmissionStatus.UNKNOWN,
     errors = Seq.empty,
     payload = payload_3
   )


### PR DESCRIPTION
This is part one - adding `actionId` and `status` to the Notification and populating these fields from `conversation Id` and `function/name Code`

Part two will be updating the FE to migrate to these new fields.
Part three will be to remove the redundant fields from the BE.

Hopefully this will minimise disruptions while migrating the change.