### PR TITLE
CEDS-1691 - Rename Notification conversationId and functionCode fields

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
@@ -110,12 +110,9 @@ class NotificationController @Inject()(
         val errors = buildErrorsFromRequest(singleResponseXml)
 
         Notification(
-          conversationId = notificationApiRequestHeaders.conversationId.value,
           actionId = notificationApiRequestHeaders.conversationId.value,
           mrn = mrn,
           dateTimeIssued = dateTimeIssued,
-          functionCode = functionCode,
-          nameCode = nameCode,
           status = SubmissionStatus.retrieve(functionCode, nameCode),
           errors = errors,
           payload = notificationXml.toString

--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
@@ -22,12 +22,9 @@ import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.SubmissionStatus
 
 case class Notification(
-  conversationId: String,
   actionId: String,
   mrn: String,
   dateTimeIssued: LocalDateTime,
-  functionCode: String,
-  nameCode: Option[String],
   status: SubmissionStatus,
   errors: Seq[NotificationError],
   payload: String

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/Action.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/Action.scala
@@ -20,6 +20,13 @@ import java.time.LocalDateTime
 
 import play.api.libs.json.Json
 
+/**
+  * Action class
+  *
+  * @param id unique id of the Action.  This is the converstationId from customs-notifications
+  * @param requestType the request type
+  * @param requestTimestamp timestamp (defaults to now)
+  */
 case class Action(id: String, requestType: RequestType, requestTimestamp: LocalDateTime = LocalDateTime.now())
 
 object Action {

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/Action.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/Action.scala
@@ -20,11 +20,7 @@ import java.time.LocalDateTime
 
 import play.api.libs.json.Json
 
-case class Action(
-  requestType: RequestType,
-  conversationId: String,
-  requestTimestamp: LocalDateTime = LocalDateTime.now()
-)
+case class Action(requestType: RequestType, id: String, requestTimestamp: LocalDateTime = LocalDateTime.now())
 
 object Action {
   implicit val format = Json.format[Action]

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/Action.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/Action.scala
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 
 import play.api.libs.json.Json
 
-case class Action(requestType: RequestType, id: String, requestTimestamp: LocalDateTime = LocalDateTime.now())
+case class Action(id: String, requestType: RequestType, requestTimestamp: LocalDateTime = LocalDateTime.now())
 
 object Action {
   implicit val format = Json.format[Action]

--- a/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
@@ -39,7 +39,7 @@ class NotificationRepository @Inject()(mc: ReactiveMongoComponent)(implicit ec: 
   override def indexes: Seq[Index] = Seq(
     Index(Seq("dateTimeIssued" -> IndexType.Ascending), name = Some("dateTimeIssuedIdx")),
     Index(Seq("mrn" -> IndexType.Ascending), name = Some("mrnIdx")),
-    Index(Seq("conversationId" -> IndexType.Ascending), name = Some("conversationIdIdx"))
+    Index(Seq("actionId" -> IndexType.Ascending), name = Some("actionIdIdx"))
   )
 
   // TODO: Need to change this method to return Future[WriteResult].
@@ -50,13 +50,13 @@ class NotificationRepository @Inject()(mc: ReactiveMongoComponent)(implicit ec: 
     res.ok
   }
 
-  def findNotificationsByConversationId(conversationId: String): Future[Seq[Notification]] =
-    find("conversationId" -> JsString(conversationId))
+  def findNotificationsByActionId(actionId: String): Future[Seq[Notification]] =
+    find("actionId" -> JsString(actionId))
 
-  def findNotificationsByConversationIds(conversationIds: Seq[String]): Future[Seq[Notification]] =
-    conversationIds match {
+  def findNotificationsByActionIds(actionIds: Seq[String]): Future[Seq[Notification]] =
+    actionIds match {
       case Seq() => Future.successful(Seq.empty)
-      case _     => find("$or" -> conversationIds.map(id => Json.obj("conversationId" -> JsString(id))))
+      case _     => find("$or" -> actionIds.map(id => Json.obj("actionId" -> JsString(id))))
     }
 
 }

--- a/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
@@ -40,7 +40,7 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
     ) {
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq("actions.conversationId" -> IndexType.Ascending), unique = true, name = Some("conversationIdIdx")),
+    Index(Seq("actions.id" -> IndexType.Ascending), unique = true, name = Some("actionIdIdx")),
     Index(Seq("eori" -> IndexType.Ascending), name = Some("eoriIdx")),
     Index(
       Seq("eori" -> IndexType.Ascending, "action.requestTimestamp" -> IndexType.Descending),
@@ -70,7 +70,7 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
   }
 
   def updateMrn(conversationId: String, newMrn: String): Future[Option[Submission]] = {
-    val query = Json.obj("actions.conversationId" -> conversationId)
+    val query = Json.obj("actions.id" -> conversationId)
     val update = Json.obj("$set" -> Json.obj("mrn" -> newMrn))
     performUpdate(query, update)
   }

--- a/app/uk/gov/hmrc/exports/services/WcoSubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/WcoSubmissionService.scala
@@ -47,7 +47,7 @@ class WcoSubmissionService @Inject()(
         eori = declaration.eori,
         lrn = lrn,
         ducr = ducr,
-        actions = Seq(Action(requestType = SubmissionRequest, conversationId = conversationId))
+        actions = Seq(Action(requestType = SubmissionRequest, id = conversationId))
       )
     }
   }

--- a/test/component/uk/gov/hmrc/exports/base/ComponentTestSpec.scala
+++ b/test/component/uk/gov/hmrc/exports/base/ComponentTestSpec.scala
@@ -98,11 +98,8 @@ trait ComponentTestSpec
   }
 
   def withNotificationRepositorySuccess(): Unit =
-    when(mockNotificationsRepository.findNotificationsByConversationId(any())).thenReturn(
-      Future.successful(
-        Seq(Notification("conversation-id", "action-id", "mrn", LocalDateTime.now(), "", None, UNKNOWN, Seq.empty, ""))
-      )
-    )
+    when(mockNotificationsRepository.findNotificationsByActionId(any()))
+      .thenReturn(Future.successful(Seq(Notification("action-id", "mrn", LocalDateTime.now(), UNKNOWN, Seq.empty, ""))))
 
   def verifySubmissionRepositoryIsCorrectlyCalled(eoriValue: String) {
     val submissionCaptor: ArgumentCaptor[Submission] = ArgumentCaptor.forClass(classOf[Submission])

--- a/test/integration/uk/gov/hmrc/exports/repositories/NotificationRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/repositories/NotificationRepositorySpec.scala
@@ -54,7 +54,7 @@ class NotificationRepositorySpec
       "return true" in {
         repo.save(notification).futureValue must be(true)
 
-        val notificationInDB = repo.findNotificationsByConversationId(conversationId).futureValue
+        val notificationInDB = repo.findNotificationsByActionId(actionId).futureValue
         notificationInDB.length must equal(1)
         notificationInDB.head must equal(notification)
       }
@@ -76,37 +76,37 @@ class NotificationRepositorySpec
 
       repo.save(notification).futureValue
 
-      val notificationsInDB = repo.findNotificationsByConversationId(notification.conversationId).futureValue
+      val notificationsInDB = repo.findNotificationsByActionId(notification.actionId).futureValue
       notificationsInDB.length must equal(2)
       notificationsInDB.head must equal(notification)
     }
   }
 
-  "Notification Repository on findNotificationsByConversationId" when {
+  "Notification Repository on findNotificationsByActionId" when {
 
-    "there is no Notification with given conversationId" should {
+    "there is no Notification with given actionId" should {
       "return empty list" in {
-        repo.findNotificationsByConversationId(conversationId).futureValue must equal(Seq.empty)
+        repo.findNotificationsByActionId(actionId).futureValue must equal(Seq.empty)
       }
     }
 
-    "there is single Notification with given conversationId" should {
+    "there is single Notification with given actionId" should {
       "return this Notification only" in {
         repo.save(notification).futureValue
 
-        val foundNotifications = repo.findNotificationsByConversationId(conversationId).futureValue
+        val foundNotifications = repo.findNotificationsByActionId(actionId).futureValue
 
         foundNotifications.length must equal(1)
         foundNotifications.head must equal(notification)
       }
     }
 
-    "there are multiple Notifications with given conversationId" should {
+    "there are multiple Notifications with given actionId" should {
       "return all the Notifications" in {
         repo.save(notification).futureValue
         repo.save(notification_2).futureValue
 
-        val foundNotifications = repo.findNotificationsByConversationId(conversationId).futureValue
+        val foundNotifications = repo.findNotificationsByActionId(actionId).futureValue
 
         foundNotifications.length must equal(2)
         foundNotifications must contain(notification)
@@ -115,21 +115,21 @@ class NotificationRepositorySpec
     }
   }
 
-  "Notification Repository on findNotificationsByConversationIds" when {
+  "Notification Repository on findNotificationsByActionIds" when {
 
-    "there is no Notification for any given conversationId" should {
+    "there is no Notification for any given actionId" should {
       "return empty list" in {
-        repo.findNotificationsByConversationIds(Seq(conversationId, conversationId_2)).futureValue must equal(Seq.empty)
+        repo.findNotificationsByActionIds(Seq(actionId, actionId_2)).futureValue must equal(Seq.empty)
       }
     }
 
-    "there are Notifications for one of provided conversationIds" should {
+    "there are Notifications for one of provided actionIds" should {
       "return those Notifications" in {
         repo.save(notification).futureValue
         repo.save(notification_2).futureValue
 
         val foundNotifications =
-          repo.findNotificationsByConversationIds(Seq(conversationId, conversationId_2)).futureValue
+          repo.findNotificationsByActionIds(Seq(actionId, actionId_2)).futureValue
 
         foundNotifications.length must equal(2)
         foundNotifications must contain(notification)
@@ -137,27 +137,27 @@ class NotificationRepositorySpec
       }
     }
 
-    "there are Notifications with different conversationIds" should {
+    "there are Notifications with different actionIds" should {
       "return only Notifications with conversationId same as provided one" in {
         repo.save(notification).futureValue
         repo.save(notification_2).futureValue
         repo.save(notification_3).futureValue
 
-        val foundNotifications = repo.findNotificationsByConversationIds(Seq(conversationId_2)).futureValue
+        val foundNotifications = repo.findNotificationsByActionIds(Seq(actionId_2)).futureValue
 
         foundNotifications.length must equal(1)
         foundNotifications must contain(notification_3)
       }
     }
 
-    "there are Notifications for all of provided conversationIds" should {
+    "there are Notifications for all of provided actionIds" should {
       "return all the Notifications" in {
         repo.save(notification).futureValue
         repo.save(notification_2).futureValue
         repo.save(notification_3).futureValue
 
         val foundNotifications =
-          repo.findNotificationsByConversationIds(Seq(conversationId, conversationId_2)).futureValue
+          repo.findNotificationsByActionIds(Seq(actionId, actionId_2)).futureValue
 
         foundNotifications.length must equal(3)
         foundNotifications must contain(notification)
@@ -172,7 +172,7 @@ class NotificationRepositorySpec
         repo.save(notification_2).futureValue
         repo.save(notification_3).futureValue
 
-        repo.findNotificationsByConversationIds(Seq.empty).futureValue must equal(Seq.empty)
+        repo.findNotificationsByActionIds(Seq.empty).futureValue must equal(Seq.empty)
       }
     }
   }

--- a/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
@@ -120,7 +120,7 @@ class SubmissionRepositorySpec
 
     "there is no Submission with given MRN" should {
       "return empty Option" in {
-        val newAction = Action(CancellationRequest, actionId_2)
+        val newAction = Action(actionId_2, CancellationRequest)
         repo.addAction(mrn, newAction).futureValue mustNot be(defined)
       }
     }
@@ -128,7 +128,7 @@ class SubmissionRepositorySpec
     "there is a Submission with given MRN" should {
       "return Submission updated" in {
         repo.save(submission).futureValue
-        val newAction = Action(CancellationRequest, actionId_2)
+        val newAction = Action(actionId_2, CancellationRequest)
         val expectedUpdatedSubmission = submission.copy(actions = submission.actions :+ newAction)
 
         val updatedSubmission = repo.addAction(mrn, newAction).futureValue

--- a/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
@@ -69,7 +69,7 @@ class SubmissionRepositorySpec
 
         exc mustBe an[DatabaseException]
         exc.getMessage must include(
-          "E11000 duplicate key error collection: customs-declare-exports.submissions index: conversationIdIdx dup key"
+          "E11000 duplicate key error collection: customs-declare-exports.submissions index: actionIdIdx dup key"
         )
       }
 
@@ -91,7 +91,7 @@ class SubmissionRepositorySpec
     "return empty Option" when {
       "there is no Submission with given ConversationId" in {
         val newMrn = mrn_2
-        repo.updateMrn(conversationId, newMrn).futureValue mustNot be(defined)
+        repo.updateMrn(actionId, newMrn).futureValue mustNot be(defined)
       }
     }
 
@@ -101,7 +101,7 @@ class SubmissionRepositorySpec
         val newMrn = mrn_2
         val expectedUpdatedSubmission = submission.copy(mrn = Some(newMrn))
 
-        val updatedSubmission = repo.updateMrn(conversationId, newMrn).futureValue
+        val updatedSubmission = repo.updateMrn(actionId, newMrn).futureValue
 
         updatedSubmission.value must equal(expectedUpdatedSubmission)
       }
@@ -109,7 +109,7 @@ class SubmissionRepositorySpec
       "new MRN is the same as the old one" in {
         repo.save(submission).futureValue
 
-        val updatedSubmission = repo.updateMrn(conversationId, mrn).futureValue
+        val updatedSubmission = repo.updateMrn(actionId, mrn).futureValue
 
         updatedSubmission.value must equal(submission)
       }
@@ -120,7 +120,7 @@ class SubmissionRepositorySpec
 
     "there is no Submission with given MRN" should {
       "return empty Option" in {
-        val newAction = Action(CancellationRequest, conversationId_2)
+        val newAction = Action(CancellationRequest, actionId_2)
         repo.addAction(mrn, newAction).futureValue mustNot be(defined)
       }
     }
@@ -128,7 +128,7 @@ class SubmissionRepositorySpec
     "there is a Submission with given MRN" should {
       "return Submission updated" in {
         repo.save(submission).futureValue
-        val newAction = Action(CancellationRequest, conversationId_2)
+        val newAction = Action(CancellationRequest, actionId_2)
         val expectedUpdatedSubmission = submission.copy(actions = submission.actions :+ newAction)
 
         val updatedSubmission = repo.addAction(mrn, newAction).futureValue

--- a/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
@@ -122,10 +122,10 @@ trait CustomsExportsBaseSpec
     when(mockSubmissionRepository.findAllSubmissionsForEori(any())).thenReturn(Future.successful(submissions))
 
   protected def withoutNotifications(): OngoingStubbing[Future[Seq[Notification]]] =
-    when(mockNotificationsRepository.findNotificationsByConversationId(any())).thenReturn(Future.successful(Seq.empty))
+    when(mockNotificationsRepository.findNotificationsByActionId(any())).thenReturn(Future.successful(Seq.empty))
 
   protected def withNotification(notifications: Seq[Notification]): OngoingStubbing[Future[Seq[Notification]]] =
-    when(mockNotificationsRepository.findNotificationsByConversationId(any()))
+    when(mockNotificationsRepository.findNotificationsByActionId(any()))
       .thenReturn(Future.successful(notifications))
 
 }

--- a/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
@@ -68,8 +68,8 @@ object UnitTestMockBuilder extends MockitoSugar {
 
   def buildNotificationRepositoryMock: NotificationRepository = {
     val notificationRepositoryMock: NotificationRepository = mock[NotificationRepository]
-    when(notificationRepositoryMock.findNotificationsByConversationId(any())).thenReturn(Future.successful(Seq.empty))
-    when(notificationRepositoryMock.findNotificationsByConversationIds(any())).thenReturn(Future.successful(Seq.empty))
+    when(notificationRepositoryMock.findNotificationsByActionId(any())).thenReturn(Future.successful(Seq.empty))
+    when(notificationRepositoryMock.findNotificationsByActionIds(any())).thenReturn(Future.successful(Seq.empty))
     when(notificationRepositoryMock.save(any())).thenReturn(Future.successful(false))
     notificationRepositoryMock
   }

--- a/test/unit/uk/gov/hmrc/exports/controllers/HeaderValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/HeaderValidatorSpec.scala
@@ -64,7 +64,7 @@ class HeaderValidatorSpec extends WordSpec with MockitoSugar with MustMatchers {
     "return conversationId from header when extract is called and header is present" in new SetUp {
       val extractedConversationId: Option[String] =
         validator.extractConversationIdHeader(ValidHeaders)
-      extractedConversationId must equal(Some(conversationId))
+      extractedConversationId must equal(Some(actionId))
     }
 
     "return None from header when extract is called and LRN header not present" in new SetUp {
@@ -145,7 +145,7 @@ class HeaderValidatorSpec extends WordSpec with MockitoSugar with MustMatchers {
 
         val result: Either[ErrorResponse, NotificationApiRequestHeaders] =
           validator.validateAndExtractNotificationHeaders(ValidHeaders)
-        result must equal(Right(NotificationApiRequestHeaders(AuthToken(dummyToken), ConversationId(conversationId))))
+        result must equal(Right(NotificationApiRequestHeaders(AuthToken(dummyToken), ConversationId(actionId))))
       }
 
       "return Left ErrorResponse when validateHeaders is called with invalid headers" in new SetUp {

--- a/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
@@ -22,12 +22,12 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.{ArgumentCaptor, InOrder, Mockito}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
 import reactivemongo.bson.{BSONDocument, BSONInteger, BSONString}
 import reactivemongo.core.errors.DetailedDatabaseException
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
-import uk.gov.hmrc.exports.models.declaration.submissions.{Action, RequestType, Submission, SubmissionRequest}
+import uk.gov.hmrc.exports.models.declaration.submissions.{Action, Submission, SubmissionRequest}
 import uk.gov.hmrc.exports.repositories.{NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.services.NotificationService
 import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder._
@@ -133,7 +133,7 @@ class NotificationServiceSpec extends WordSpec with MockitoSugar with ScalaFutur
 
   "Get Notifications" should {
     val notifications = mock[Seq[Notification]]
-    val submission = Submission("id", "eori", "lrn", None, "ducr", Seq(Action(SubmissionRequest, "id1")))
+    val submission = Submission("id", "eori", "lrn", None, "ducr", Seq(Action("id1", SubmissionRequest)))
 
     "retrieve by conversation IDs" in new Test {
       when(notificationRepositoryMock.findNotificationsByActionIds(any[Seq[String]]))

--- a/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
@@ -71,7 +71,7 @@ class NotificationServiceSpec extends WordSpec with MockitoSugar with ScalaFutur
 
         val inOrder: InOrder = Mockito.inOrder(submissionRepositoryMock, notificationRepositoryMock)
         inOrder.verify(submissionRepositoryMock, times(1)).findAllSubmissionsForEori(any())
-        inOrder.verify(notificationRepositoryMock, times(1)).findNotificationsByConversationIds(any())
+        inOrder.verify(notificationRepositoryMock, times(1)).findNotificationsByActionIds(any())
       }
 
       "call SubmissionRepository, passing EORI provided" in new GetAllNotificationsForUserHappyPathTest {
@@ -84,19 +84,19 @@ class NotificationServiceSpec extends WordSpec with MockitoSugar with ScalaFutur
         notificationService.getAllNotificationsForUser(eori).futureValue
 
         val conversationIdCaptor: ArgumentCaptor[Seq[String]] = ArgumentCaptor.forClass(classOf[Seq[String]])
-        verify(notificationRepositoryMock, times(1)).findNotificationsByConversationIds(conversationIdCaptor.capture())
+        verify(notificationRepositoryMock, times(1)).findNotificationsByActionIds(conversationIdCaptor.capture())
         val actualConversationIds: Seq[String] = conversationIdCaptor.getValue
         actualConversationIds.length must equal(2)
-        actualConversationIds must contain(notification.conversationId)
-        actualConversationIds must contain(notification_2.conversationId)
-        actualConversationIds must contain(notification_3.conversationId)
+        actualConversationIds must contain(notification.actionId)
+        actualConversationIds must contain(notification_2.actionId)
+        actualConversationIds must contain(notification_3.actionId)
       }
 
       trait GetAllNotificationsForUserHappyPathTest extends Test {
         when(submissionRepositoryMock.findAllSubmissionsForEori(any()))
           .thenReturn(Future.successful(Seq(submission, submission_2)))
         val notificationsToBeReturned = Seq(notification, notification_2, notification_3)
-        when(notificationRepositoryMock.findNotificationsByConversationIds(any()))
+        when(notificationRepositoryMock.findNotificationsByActionIds(any()))
           .thenReturn(Future.successful(notificationsToBeReturned))
       }
     }
@@ -123,7 +123,7 @@ class NotificationServiceSpec extends WordSpec with MockitoSugar with ScalaFutur
       "return empty list" in new Test {
         when(submissionRepositoryMock.findAllSubmissionsForEori(any()))
           .thenReturn(Future.successful(Seq(submission, submission_2)))
-        when(notificationRepositoryMock.findNotificationsByConversationIds(any()))
+        when(notificationRepositoryMock.findNotificationsByActionIds(any()))
           .thenReturn(Future.successful(Seq.empty))
 
         notificationService.getAllNotificationsForUser(eori).futureValue must equal(Seq.empty)
@@ -136,12 +136,12 @@ class NotificationServiceSpec extends WordSpec with MockitoSugar with ScalaFutur
     val submission = Submission("id", "eori", "lrn", None, "ducr", Seq(Action(SubmissionRequest, "id1")))
 
     "retrieve by conversation IDs" in new Test {
-      when(notificationRepositoryMock.findNotificationsByConversationIds(any[Seq[String]]))
+      when(notificationRepositoryMock.findNotificationsByActionIds(any[Seq[String]]))
         .thenReturn(Future.successful(notifications))
 
       notificationService.getNotifications(submission).futureValue mustBe notifications
 
-      verify(notificationRepositoryMock).findNotificationsByConversationIds(Seq("id1"))
+      verify(notificationRepositoryMock).findNotificationsByActionIds(Seq("id1"))
     }
   }
 
@@ -170,7 +170,7 @@ class NotificationServiceSpec extends WordSpec with MockitoSugar with ScalaFutur
       "call SubmissionRepository passing conversation ID and MRN provided in the Notification" in new SaveHappyPathTest {
         notificationService.save(notification).futureValue
 
-        verify(submissionRepositoryMock, times(1)).updateMrn(meq(conversationId), meq(mrn))
+        verify(submissionRepositoryMock, times(1)).updateMrn(meq(actionId), meq(mrn))
       }
 
       trait SaveHappyPathTest extends Test {

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -114,17 +114,14 @@ class SubmissionServiceSpec extends WordSpec with MockitoSugar with ScalaFutures
         val submission: Submission =
           Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
         val notification = Notification(
-          "conversation-id",
           "action-id",
           "mrn",
           LocalDateTime.now(),
-          "",
-          None,
           status = SubmissionStatus.UNKNOWN,
           Seq.empty,
           ""
         )
-        when(notificationRepositoryMock.findNotificationsByConversationId("conversation-id"))
+        when(notificationRepositoryMock.findNotificationsByActionId("conversation-id"))
           .thenReturn(Future.successful(Seq(notification)))
         when(submissionRepositoryMock.updateMrn("conversation-id", "mrn"))
           .thenReturn(Future.successful(Some(submission)))

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -113,14 +113,8 @@ class SubmissionServiceSpec extends WordSpec with MockitoSugar with ScalaFutures
       "some notifications" in new Test {
         val submission: Submission =
           Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
-        val notification = Notification(
-          "action-id",
-          "mrn",
-          LocalDateTime.now(),
-          status = SubmissionStatus.UNKNOWN,
-          Seq.empty,
-          ""
-        )
+        val notification =
+          Notification("action-id", "mrn", LocalDateTime.now(), status = SubmissionStatus.UNKNOWN, Seq.empty, "")
         when(notificationRepositoryMock.findNotificationsByActionId("conversation-id"))
           .thenReturn(Future.successful(Seq(notification)))
         when(submissionRepositoryMock.updateMrn("conversation-id", "mrn"))

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -63,7 +63,7 @@ class SubmissionServiceSpec extends WordSpec with MockitoSugar with ScalaFutures
 
   "cancel" should {
     val submission = Submission("id", "eori", "lrn", None, "ducr")
-    val submissionCancelled = Submission("id", "eori", "lrn", None, "ducr", Seq(Action(CancellationRequest, "conv-id")))
+    val submissionCancelled = Submission("id", "eori", "lrn", None, "ducr", Seq(Action("conv-id", CancellationRequest)))
     val cancellation = SubmissionCancellation("ref-id", "mrn", "description", "reason")
 
     "submit and delegate to repository" when {
@@ -105,14 +105,14 @@ class SubmissionServiceSpec extends WordSpec with MockitoSugar with ScalaFutures
     "delegate to the repository" when {
       "no notifications" in new Test {
         val submission: Submission =
-          Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
+          Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action("conversation-id", SubmissionRequest)))
 
         submissionService.create(submission).futureValue mustBe submission
       }
 
       "some notifications" in new Test {
         val submission: Submission =
-          Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action(SubmissionRequest, "conversation-id")))
+          Submission(eori = "", lrn = "", ducr = "", actions = Seq(Action("conversation-id", SubmissionRequest)))
         val notification =
           Notification("action-id", "mrn", LocalDateTime.now(), status = SubmissionStatus.UNKNOWN, Seq.empty, "")
         when(notificationRepositoryMock.findNotificationsByActionId("conversation-id"))

--- a/test/util/testdata/ExportsTestData.scala
+++ b/test/util/testdata/ExportsTestData.scala
@@ -32,9 +32,9 @@ object ExportsTestData {
   val lrn: String = randomAlphanumericString(22)
   val mrn: String = "MRN87878797"
   val mrn_2: String = "MRN12341234"
-  val conversationId: String = "b1c09f1b-7c94-4e90-b754-7c5c71c44e11"
-  val conversationId_2: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e22"
-  val conversationId_3: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e33"
+  val actionId: String = "b1c09f1b-7c94-4e90-b754-7c5c71c44e11"
+  val actionId_2: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e22"
+  val actionId_3: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e33"
 
   val authToken: String =
     "BXQ3/Treo4kQCZvVcCqKPlwxRN4RA9Mb5RF8fFxOuwG5WSg+S+Rsp9Nq998Fgg0HeNLXL7NGwEAIzwM6vuA6YYhRQnTRFaBhrp+1w+kVW8g1qHGLYO48QPWuxdM87VMCZqxnCuDoNxVn76vwfgtpNj0+NwfzXV2Zc12L2QGgF9H9KwIkeIPK/mMlBESjue4V]"
@@ -49,7 +49,7 @@ object ExportsTestData {
   val Valid_X_EORI_IDENTIFIER_HEADER: (String, String) = XEoriIdentifierHeaderName -> declarantEoriValue
   val Valid_LRN_HEADER: (String, String) = XLrnHeaderName -> declarantLrnValue
   val Valid_AUTHORIZATION_HEADER: (String, String) = HeaderNames.AUTHORIZATION -> dummyToken
-  val VALID_CONVERSATIONID_HEADER: (String, String) = XConversationIdName -> conversationId
+  val VALID_CONVERSATIONID_HEADER: (String, String) = XConversationIdName -> actionId
   val VALID_DUCR_HEADER: (String, String) = XDucrHeaderName -> declarantDucrValue
   val VALID_MRN_HEADER: (String, String) = XMrnHeaderName -> declarantMrnValue
   val now: DateTime = DateTime.now.withZone(DateTimeZone.UTC)

--- a/test/util/testdata/NotificationTestData.scala
+++ b/test/util/testdata/NotificationTestData.scala
@@ -252,34 +252,25 @@ object NotificationTestData {
   val payload_3 = TestDataHelper.randomAlphanumericString(payloadExemplaryLength)
 
   val notification = Notification(
-    conversationId = conversationId,
-    actionId = conversationId,
+    actionId = actionId,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued,
-    functionCode = functionCode,
-    nameCode = nameCode,
     status = SubmissionStatus.UNKNOWN,
     errors = errors,
     payload = payload
   )
   val notification_2 = Notification(
-    conversationId = conversationId,
-    actionId = conversationId,
+    actionId = actionId,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued_2,
-    functionCode = functionCode_2,
-    nameCode = nameCode,
     status = SubmissionStatus.UNKNOWN,
     errors = errors,
     payload = payload_2
   )
   val notification_3 = Notification(
-    conversationId = conversationId_2,
-    actionId = conversationId_2,
+    actionId = actionId_2,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued_3,
-    functionCode = functionCode_3,
-    nameCode = nameCode,
     status = SubmissionStatus.UNKNOWN,
     errors = Seq.empty,
     payload = payload_3

--- a/test/util/testdata/SubmissionTestData.scala
+++ b/test/util/testdata/SubmissionTestData.scala
@@ -24,20 +24,20 @@ import util.testdata.ExportsTestData._
 
 object SubmissionTestData {
 
-  lazy val action = Action(requestType = SubmissionRequest, conversationId = conversationId)
+  lazy val action = Action(requestType = SubmissionRequest, id = actionId)
   lazy val action_2 = Action(
     requestType = SubmissionRequest,
-    conversationId = conversationId_2,
+    id = actionId_2,
     requestTimestamp = LocalDateTime.of(1971, 1, 1, 1, 1)
   )
   lazy val action_3 = Action(
     requestType = SubmissionRequest,
-    conversationId = conversationId_3,
+    id = actionId_3,
     requestTimestamp = LocalDateTime.of(1972, 1, 1, 1, 1)
   )
   lazy val actionCancellation = Action(
     requestType = CancellationRequest,
-    conversationId = conversationId,
+    id = actionId,
     requestTimestamp = action.requestTimestamp.plusHours(3)
   )
   lazy val submission: Submission =

--- a/test/util/testdata/SubmissionTestData.scala
+++ b/test/util/testdata/SubmissionTestData.scala
@@ -25,21 +25,12 @@ import util.testdata.ExportsTestData._
 object SubmissionTestData {
 
   lazy val action = Action(requestType = SubmissionRequest, id = actionId)
-  lazy val action_2 = Action(
-    requestType = SubmissionRequest,
-    id = actionId_2,
-    requestTimestamp = LocalDateTime.of(1971, 1, 1, 1, 1)
-  )
-  lazy val action_3 = Action(
-    requestType = SubmissionRequest,
-    id = actionId_3,
-    requestTimestamp = LocalDateTime.of(1972, 1, 1, 1, 1)
-  )
-  lazy val actionCancellation = Action(
-    requestType = CancellationRequest,
-    id = actionId,
-    requestTimestamp = action.requestTimestamp.plusHours(3)
-  )
+  lazy val action_2 =
+    Action(requestType = SubmissionRequest, id = actionId_2, requestTimestamp = LocalDateTime.of(1971, 1, 1, 1, 1))
+  lazy val action_3 =
+    Action(requestType = SubmissionRequest, id = actionId_3, requestTimestamp = LocalDateTime.of(1972, 1, 1, 1, 1))
+  lazy val actionCancellation =
+    Action(requestType = CancellationRequest, id = actionId, requestTimestamp = action.requestTimestamp.plusHours(3))
   lazy val submission: Submission =
     Submission(uuid = uuid, eori = eori, lrn = lrn, mrn = Some(mrn), ducr = ducr, actions = Seq(action))
   lazy val submission_2: Submission =


### PR DESCRIPTION
This is second part.  Removes (now) redundant fields and also renames action.conversationId field.

This change is no longer backwards-compatible and will require clearing the `customs-declare-exports` collections.