### PR TITLE
Index fixes

### DIFF
--- a/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
@@ -22,7 +22,7 @@ import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.Cursor.FailOnError
 import reactivemongo.api.ReadPreference
 import reactivemongo.api.indexes.{Index, IndexType}
-import reactivemongo.bson.BSONObjectID
+import reactivemongo.bson.{BSONBoolean, BSONDocument, BSONObjectID}
 import reactivemongo.play.json.commands.JSONFindAndModifyCommand.FindAndModifyResult
 import uk.gov.hmrc.exports.models.Eori
 import uk.gov.hmrc.exports.models.declaration.ExportsDeclaration
@@ -42,7 +42,12 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
     ) {
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq("actions.id" -> IndexType.Ascending), unique = true, name = Some("actionIdIdx")),
+    Index(
+      Seq("actions.id" -> IndexType.Ascending),
+      unique = true,
+      name = Some("actionIdIdx"),
+      partialFilter = Some(BSONDocument(Seq("actions.id" -> BSONDocument("$exists" -> BSONBoolean(true)))))
+    ),
     Index(Seq("eori" -> IndexType.Ascending), name = Some("eoriIdx")),
     Index(
       Seq("eori" -> IndexType.Ascending, "action.requestTimestamp" -> IndexType.Descending),

--- a/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
@@ -87,6 +87,12 @@ class SubmissionRepositorySpec
         submissionsInDB.head must equal(submission)
       }
     }
+
+    "allow save two submissions with empty actions" in {
+      repo.save(emptySubmission_1).futureValue must be(emptySubmission_1)
+      repo.save(emptySubmission_2).futureValue must be(emptySubmission_2)
+      repo.findAllSubmissionsForEori(eori).futureValue must have length 2
+    }
   }
 
   "Submission Repository on updateMrn" should {

--- a/test/util/testdata/SubmissionTestData.scala
+++ b/test/util/testdata/SubmissionTestData.scala
@@ -48,4 +48,9 @@ object SubmissionTestData {
   val uuid: String = UUID.randomUUID().toString
   val uuid_2: String = UUID.randomUUID().toString
   val uuid_3: String = UUID.randomUUID().toString
+
+  val emptySubmission_1 = Submission(uuid = uuid, eori = eori, lrn = lrn, mrn = Some(mrn), ducr = ducr, actions = Seq())
+
+  val emptySubmission_2 =
+    Submission(uuid = uuid_2, eori = eori, lrn = lrn, mrn = Some(mrn_2), ducr = ducr, actions = Seq())
 }


### PR DESCRIPTION
Empty actions array in submission were indexed as null for `action.id` index. 
Moving `action.id` index as partial index only for document that have at least one action.