### PR TITLE
CEDS-1779 Ensure Back End owns Status changes

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/SubmissionController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/SubmissionController.scala
@@ -19,8 +19,8 @@ package uk.gov.hmrc.exports.controllers
 import javax.inject.{Inject, Singleton}
 import play.api.mvc._
 import uk.gov.hmrc.exports.controllers.actions.Authenticator
+import uk.gov.hmrc.exports.controllers.response.ErrorResponse
 import uk.gov.hmrc.exports.controllers.util.HeaderValidator
-import uk.gov.hmrc.exports.models.declaration.submissions.Submission
 import uk.gov.hmrc.exports.services.{DeclarationService, SubmissionService}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -39,9 +39,9 @@ class SubmissionController @Inject()(
     declarationService.findOne(id, request.eori).flatMap {
       case Some(declaration) =>
         if (declaration.isCompleted) {
-          submissionService.submit(declaration).map(Created.apply[Submission])
+          Future.successful(Conflict(ErrorResponse("Declaration has already been submitted")))
         } else {
-          Future.successful(Conflict("Could not submit incomplete declaration"))
+          submissionService.submit(declaration).map(Created(_))
         }
       case None => Future.successful(NotFound)
     }

--- a/app/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequest.scala
+++ b/app/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequest.scala
@@ -24,7 +24,6 @@ import uk.gov.hmrc.exports.models.declaration._
 import uk.gov.hmrc.exports.models.{Choice, Eori}
 
 case class ExportsDeclarationRequest(
-  status: DeclarationStatus,
   createdDateTime: Instant,
   updatedDateTime: Instant,
   sourceId: Option[String] = None,
@@ -45,7 +44,7 @@ case class ExportsDeclarationRequest(
   def toExportsDeclaration(id: String, eori: Eori): ExportsDeclaration = ExportsDeclaration(
     id = id,
     eori = eori.value,
-    status = this.status,
+    status = DeclarationStatus.DRAFT,
     createdDateTime = this.createdDateTime,
     updatedDateTime = this.updatedDateTime,
     sourceId = this.sourceId,

--- a/app/uk/gov/hmrc/exports/services/SubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/SubmissionService.scala
@@ -66,7 +66,11 @@ class SubmissionService @Inject()(
 
     for {
       // Create the Submission
-      submission <- submissionRepository.findOrCreate(Eori(declaration.eori), declaration.id, Submission(declaration, lrn, ducr))
+      submission <- submissionRepository.findOrCreate(
+        Eori(declaration.eori),
+        declaration.id,
+        Submission(declaration, lrn, ducr)
+      )
 
       // Submit the declaration to the Dec API
       conversationId <- customsDeclarationsConnector.submitDeclaration(declaration.eori, payload)

--- a/app/uk/gov/hmrc/exports/services/SubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/SubmissionService.scala
@@ -78,8 +78,9 @@ class SubmissionService @Inject()(
   private def appendMRNIfAlreadyAvailable(submission: Submission, actionId: String): Future[Submission] =
     notificationRepository.findNotificationsByActionId(actionId).flatMap { notifications =>
       notifications.headOption match {
-        case Some(notification) => submissionRepository.updateMrn(actionId, notification.mrn).map(_.getOrElse(submission))
-        case None               => Future.successful(submission)
+        case Some(notification) =>
+          submissionRepository.updateMrn(actionId, notification.mrn).map(_.getOrElse(submission))
+        case None => Future.successful(submission)
       }
     }
 

--- a/test/component/uk/gov/hmrc/exports/ExportsSubmissionReceivedSpec.scala
+++ b/test/component/uk/gov/hmrc/exports/ExportsSubmissionReceivedSpec.scala
@@ -127,9 +127,9 @@ class ExportsSubmissionReceivedSpec
         .And(`User has been authorized`)
     }
 
-    Scenario("authorized user tries to submit draft") {
+    Scenario("authorized user tries to submit pre-submitted declaration") {
       _.Given(`Authorized user`)
-        .And(`User has incomplete declaration`)
+        .And(`User has pre-submitted declaration`)
         .When(`User perform declaration submission`)
         .Then(`Result status` is CONFLICT)
         .And(`No submission was created`)

--- a/test/component/uk/gov/hmrc/exports/steps/DeclarationSteps.scala
+++ b/test/component/uk/gov/hmrc/exports/steps/DeclarationSteps.scala
@@ -18,17 +18,30 @@ package component.uk.gov.hmrc.exports.steps
 
 import java.util.UUID
 
-import component.uk.gov.hmrc.exports.steps.`User has completed declaration`.{aDeclaration, withChoice, withConsignmentReferences, withContainerData, withEori, withId, withStatus}
+import component.uk.gov.hmrc.exports.steps.`User has completed declaration`.{
+  aDeclaration,
+  withChoice,
+  withConsignmentReferences,
+  withContainerData,
+  withEori,
+  withId,
+  withStatus
+}
 import component.uk.gov.hmrc.exports.syntax.{Action, Precondition, ScenarioContext}
 import org.scalatest.concurrent.{AbstractPatienceConfiguration, IntegrationPatience, PatienceConfiguration}
 import play.api.Application
 import play.api.test.FakeRequest
 import uk.gov.hmrc.exports.models.{Choice, Eori}
-import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration, Seal, TransportInformationContainer}
+import uk.gov.hmrc.exports.models.declaration.{
+  DeclarationStatus,
+  ExportsDeclaration,
+  Seal,
+  TransportInformationContainer
+}
 import uk.gov.hmrc.exports.repositories.DeclarationRepository
 import util.stubs.CustomsDeclarationsAPIService
 import util.testdata.ExportsDeclarationBuilder
-import util.testdata.ExportsTestData.{ValidHeaders, declarantLrnValue}
+import util.testdata.ExportsTestData.{declarantLrnValue, ValidHeaders}
 
 import scala.concurrent.{Await, Future}
 import org.mockito.ArgumentMatchers._
@@ -55,8 +68,9 @@ object `User has completed declaration` extends Precondition with ExportsDeclara
     )
     val repo = context.get[DeclarationRepository]
     when(repo.find(any(), any())).thenReturn(Future.successful(Some(declaration)))
-    when(repo.update(any()), atLeastOnce()).thenAnswer(new Answer[Future[Option[ExportsDeclaration]]]{
-      override def answer(invocation: InvocationOnMock): Future[Option[ExportsDeclaration]] = Future.successful(Some(invocation.getArgument(0)))
+    when(repo.update(any()), atLeastOnce()).thenAnswer(new Answer[Future[Option[ExportsDeclaration]]] {
+      override def answer(invocation: InvocationOnMock): Future[Option[ExportsDeclaration]] =
+        Future.successful(Some(invocation.getArgument(0)))
     })
     context.updated(declaration)
   }

--- a/test/integration/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorSpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorSpec.scala
@@ -34,6 +34,7 @@ import util.testdata.ExportsDeclarationBuilder
 import util.testdata.ExportsTestData._
 
 import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
 
 class CustomsDeclarationsConnectorSpec
     extends IntegrationTestSpec with GuiceOneAppPerSuite with MockitoSugar with CustomsDeclarationsAPIService
@@ -64,8 +65,8 @@ class CustomsDeclarationsConnectorSpec
 
       "request is processed successfully - 202" in {
 
-        startSubmissionService(ACCEPTED, UUID.randomUUID.toString)
-        await(sendValidXml(expectedSubmissionRequestPayload("123")))
+        startSubmissionService(ACCEPTED, UUID.randomUUID.toString, 120000)
+        await(sendValidXml(expectedSubmissionRequestPayload("123")))(FiniteDuration(125, "s"))
 
         verifyDecServiceWasCalledCorrectly(
           requestBody = expectedSubmissionRequestPayload("123"),

--- a/test/integration/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorSpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorSpec.scala
@@ -34,7 +34,6 @@ import util.testdata.ExportsDeclarationBuilder
 import util.testdata.ExportsTestData._
 
 import scala.concurrent.Future
-import scala.concurrent.duration.FiniteDuration
 
 class CustomsDeclarationsConnectorSpec
     extends IntegrationTestSpec with GuiceOneAppPerSuite with MockitoSugar with CustomsDeclarationsAPIService
@@ -65,8 +64,8 @@ class CustomsDeclarationsConnectorSpec
 
       "request is processed successfully - 202" in {
 
-        startSubmissionService(ACCEPTED, UUID.randomUUID.toString, 120000)
-        await(sendValidXml(expectedSubmissionRequestPayload("123")))(FiniteDuration(125, "s"))
+        startSubmissionService(ACCEPTED, UUID.randomUUID.toString)
+        await(sendValidXml(expectedSubmissionRequestPayload("123")))
 
         verifyDecServiceWasCalledCorrectly(
           requestBody = expectedSubmissionRequestPayload("123"),

--- a/test/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
+++ b/test/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
@@ -26,7 +26,6 @@ import util.testdata.ExportsDeclarationBuilder
 
 class ExportsDeclarationRequestSpec extends WordSpec with Matchers with ExportsDeclarationBuilder with MockitoSugar {
 
-  private val status = DeclarationStatus.COMPLETE
   private val choice = Choice.StandardDec
   private val createdDate = Instant.MIN
   private val updatedDate = Instant.MAX
@@ -47,7 +46,6 @@ class ExportsDeclarationRequestSpec extends WordSpec with Matchers with ExportsD
   private val natureOfTransaction = mock[NatureOfTransaction]
 
   private val request = ExportsDeclarationRequest(
-    status = status,
     createdDateTime = createdDate,
     updatedDateTime = updatedDate,
     sourceId = Some(sourceId),
@@ -69,7 +67,7 @@ class ExportsDeclarationRequestSpec extends WordSpec with Matchers with ExportsD
   private val declaration = ExportsDeclaration(
     id = id,
     eori = eori,
-    status = status,
+    status = DeclarationStatus.DRAFT,
     createdDateTime = createdDate,
     updatedDateTime = updatedDate,
     sourceId = Some(sourceId),

--- a/test/unit/uk/gov/hmrc/exports/controllers/DeclarationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/DeclarationControllerSpec.scala
@@ -431,7 +431,6 @@ class DeclarationControllerSpec
 
   def aDeclarationRequest() =
     ExportsDeclarationRequest(
-      status = DeclarationStatus.COMPLETE,
       createdDateTime = Instant.now(),
       updatedDateTime = Instant.now(),
       choice = Choice.StandardDec

--- a/test/unit/uk/gov/hmrc/exports/controllers/SubmissionControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/SubmissionControllerSpec.scala
@@ -30,24 +30,88 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.{AuthConnector, InsufficientEnrolments}
+import uk.gov.hmrc.exports.controllers.response.ErrorResponse
+import uk.gov.hmrc.exports.models.declaration.DeclarationStatus
 import uk.gov.hmrc.exports.models.declaration.submissions._
-import uk.gov.hmrc.exports.services.SubmissionService
+import uk.gov.hmrc.exports.services.{DeclarationService, SubmissionService}
 import unit.uk.gov.hmrc.exports.base.AuthTestSupport
+import util.testdata.ExportsDeclarationBuilder
 
 import scala.concurrent.Future
 
 class SubmissionControllerSpec
     extends WordSpec with GuiceOneAppPerSuite with AuthTestSupport with BeforeAndAfterEach with ScalaFutures
-    with MustMatchers {
+    with MustMatchers with ExportsDeclarationBuilder {
 
   override lazy val app: Application = GuiceApplicationBuilder()
-    .overrides(bind[AuthConnector].to(mockAuthConnector), bind[SubmissionService].to(submissionService))
+    .overrides(bind[AuthConnector].to(mockAuthConnector), bind[SubmissionService].to(submissionService), bind[DeclarationService].to(declarationService))
     .build()
   private val submissionService: SubmissionService = mock[SubmissionService]
+  private val declarationService: DeclarationService = mock[DeclarationService]
 
   override def beforeEach(): Unit = {
     super.beforeEach()
-    reset(mockAuthConnector, submissionService)
+    reset(mockAuthConnector, submissionService, declarationService)
+  }
+
+  "Create" should {
+    val post = FakeRequest("POST", "/declarations/id/submission")
+
+    "return 201" when {
+      val declaration = aDeclaration(withId("id"), withStatus(DeclarationStatus.DRAFT))
+      val submission = Submission("id", userEori.value, "lrn", None, "ducr")
+
+      "request is valid" in {
+        withAuthorizedUser()
+        given(declarationService.findOne(any(), any())).willReturn(Future.successful(Some(declaration)))
+        given(submissionService.submit(any())(any())).willReturn(Future.successful(submission))
+
+        val result: Future[Result] = route(app, post).get
+
+        status(result) mustBe CREATED
+        contentAsJson(result) mustBe toJson(submission)
+      }
+    }
+
+    "return 409" when {
+      val declaration = aDeclaration(withId("id"), withStatus(DeclarationStatus.COMPLETE))
+      val submission = Submission("id", userEori.value, "lrn", None, "ducr")
+
+      "declaration is complete" in {
+        withAuthorizedUser()
+        given(declarationService.findOne(any(), any())).willReturn(Future.successful(Some(declaration)))
+        given(submissionService.submit(any())(any())).willReturn(Future.successful(submission))
+
+        val result: Future[Result] = route(app, post).get
+
+        status(result) mustBe CONFLICT
+        contentAsJson(result) mustBe toJson(ErrorResponse("Declaration has already been submitted"))
+      }
+    }
+
+    "return 404" when {
+      "declaration is not found" in {
+        withAuthorizedUser()
+        given(declarationService.findOne(any(), any())).willReturn(Future.successful(None))
+
+        val result: Future[Result] = route(app, post).get
+
+        status(result) mustBe NOT_FOUND
+        verifyZeroInteractions(submissionService)
+      }
+    }
+
+    "return 401" when {
+      "unauthorized" in {
+        withUnauthorizedUser(InsufficientEnrolments())
+        given(declarationService.findOne(any(), any())).willReturn(Future.successful(None))
+
+        val result: Future[Result] = route(app, post).get
+
+        status(result) mustBe UNAUTHORIZED
+        verifyZeroInteractions(submissionService)
+      }
+    }
   }
 
   "Find All" should {

--- a/test/unit/uk/gov/hmrc/exports/controllers/SubmissionControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/SubmissionControllerSpec.scala
@@ -44,7 +44,11 @@ class SubmissionControllerSpec
     with MustMatchers with ExportsDeclarationBuilder {
 
   override lazy val app: Application = GuiceApplicationBuilder()
-    .overrides(bind[AuthConnector].to(mockAuthConnector), bind[SubmissionService].to(submissionService), bind[DeclarationService].to(declarationService))
+    .overrides(
+      bind[AuthConnector].to(mockAuthConnector),
+      bind[SubmissionService].to(submissionService),
+      bind[DeclarationService].to(declarationService)
+    )
     .build()
   private val submissionService: SubmissionService = mock[SubmissionService]
   private val declarationService: DeclarationService = mock[DeclarationService]

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -28,13 +28,22 @@ import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.models.declaration.submissions._
-import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration, GoodsLocation, TransportInformationContainer}
+import uk.gov.hmrc.exports.models.declaration.{
+  DeclarationStatus,
+  ExportsDeclaration,
+  GoodsLocation,
+  TransportInformationContainer
+}
 import uk.gov.hmrc.exports.models.{LocalReferenceNumber, SubmissionRequestHeaders}
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.services.mapping.MetaDataBuilder
 import uk.gov.hmrc.exports.services.{SubmissionService, WcoMapperService}
 import uk.gov.hmrc.http.HeaderCarrier
-import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder.{buildCustomsDeclarationsConnectorMock, buildNotificationRepositoryMock, buildSubmissionRepositoryMock}
+import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder.{
+  buildCustomsDeclarationsConnectorMock,
+  buildNotificationRepositoryMock,
+  buildSubmissionRepositoryMock
+}
 import util.testdata.ExportsTestData._
 import util.testdata.SubmissionTestData._
 import util.testdata.{ExportsDeclarationBuilder, NotificationTestData}

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -62,7 +62,14 @@ class SubmissionServiceSpec
   )(ExecutionContext.global)
 
   override def afterEach(): Unit = {
-    reset(customsDeclarationsConnector, submissionRepository, declarationRepository, notificationRepository, metaDataBuilder, wcoMapperService)
+    reset(
+      customsDeclarationsConnector,
+      submissionRepository,
+      declarationRepository,
+      notificationRepository,
+      metaDataBuilder,
+      wcoMapperService
+    )
     super.afterEach()
   }
 
@@ -75,7 +82,8 @@ class SubmissionServiceSpec
       "submission exists" in {
         when(metaDataBuilder.buildRequest(any(), any(), any(), any(), any())).thenReturn(mock[MetaData])
         when(wcoMapperService.toXml(any())).thenReturn("xml")
-        when(customsDeclarationsConnector.submitCancellation(any(), any())(any())).thenReturn(Future.successful("conv-id"))
+        when(customsDeclarationsConnector.submitCancellation(any(), any())(any()))
+          .thenReturn(Future.successful("conv-id"))
         when(submissionRepository.findSubmissionByMrn(any())).thenReturn(Future.successful(Some(submission)))
         when(submissionRepository.addAction(any[String](), any())).thenReturn(Future.successful(Some(submission)))
 
@@ -137,7 +145,8 @@ class SubmissionServiceSpec
         when(wcoMapperService.toXml(any())).thenReturn("xml")
         when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
         when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
-        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any())).thenReturn(Future.successful("conv-id"))
+        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any()))
+          .thenReturn(Future.successful("conv-id"))
         when(submissionRepository.addAction(any[Submission](), any())).thenReturn(Future.successful(submission))
         when(notificationRepository.findNotificationsByActionId(anyString())).thenReturn(Future.successful(Seq.empty))
 
@@ -162,9 +171,11 @@ class SubmissionServiceSpec
         when(wcoMapperService.toXml(any())).thenReturn("xml")
         when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
         when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
-        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any())).thenReturn(Future.successful("conv-id"))
+        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any()))
+          .thenReturn(Future.successful("conv-id"))
         when(submissionRepository.addAction(any[Submission](), any())).thenReturn(Future.successful(mock[Submission]))
-        when(notificationRepository.findNotificationsByActionId(anyString())).thenReturn(Future.successful(Seq(notification)))
+        when(notificationRepository.findNotificationsByActionId(anyString()))
+          .thenReturn(Future.successful(Seq(notification)))
         when(submissionRepository.updateMrn(any(), any())).thenReturn(Future.successful(Some(submission)))
 
         // When
@@ -190,7 +201,8 @@ class SubmissionServiceSpec
         when(wcoMapperService.toXml(any())).thenReturn("xml")
         when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
         when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
-        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any())).thenReturn(Future.failed(new RuntimeException("Some error")))
+        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any()))
+          .thenReturn(Future.failed(new RuntimeException("Some error")))
 
         val declaration = aDeclaration()
 

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -16,64 +16,54 @@
 
 package unit.uk.gov.hmrc.exports.services
 
-import java.util.UUID
+import java.time.LocalDateTime
 
-import com.google.inject.{Guice, Injector}
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.{any, eq => meq}
+import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.models.declaration.submissions._
-import uk.gov.hmrc.exports.models.declaration.{
-  DeclarationStatus,
-  ExportsDeclaration,
-  GoodsLocation,
-  TransportInformationContainer
-}
+import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration}
 import uk.gov.hmrc.exports.models.{LocalReferenceNumber, SubmissionRequestHeaders}
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.services.mapping.MetaDataBuilder
 import uk.gov.hmrc.exports.services.{SubmissionService, WcoMapperService}
 import uk.gov.hmrc.http.HeaderCarrier
-import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder.{
-  buildCustomsDeclarationsConnectorMock,
-  buildNotificationRepositoryMock,
-  buildSubmissionRepositoryMock
-}
+import util.testdata.ExportsDeclarationBuilder
 import util.testdata.ExportsTestData._
 import util.testdata.SubmissionTestData._
-import util.testdata.{ExportsDeclarationBuilder, NotificationTestData}
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
 
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.NodeSeq
 
 class SubmissionServiceSpec
     extends WordSpec with MockitoSugar with ScalaFutures with MustMatchers with ExportsDeclarationBuilder
-    with Eventually {
+    with Eventually with BeforeAndAfterEach {
 
-  val injector: Injector = Guice.createInjector()
+  private implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+  private val customsDeclarationsConnector: CustomsDeclarationsConnector = mock[CustomsDeclarationsConnector]
+  private val submissionRepository: SubmissionRepository = mock[SubmissionRepository]
+  private val declarationRepository: DeclarationRepository = mock[DeclarationRepository]
+  private val notificationRepository: NotificationRepository = mock[NotificationRepository]
+  private val metaDataBuilder: MetaDataBuilder = mock[MetaDataBuilder]
+  private val wcoMapperService: WcoMapperService = mock[WcoMapperService]
+  private val submissionService = new SubmissionService(
+    customsDeclarationsConnector = customsDeclarationsConnector,
+    submissionRepository = submissionRepository,
+    declarationRepository = declarationRepository,
+    notificationRepository = notificationRepository,
+    metaDataBuilder = metaDataBuilder,
+    wcoMapperService = wcoMapperService
+  )(ExecutionContext.global)
 
-  private trait Test {
-    implicit val hc: HeaderCarrier = mock[HeaderCarrier]
-    val customsDeclarationsConnectorMock: CustomsDeclarationsConnector = buildCustomsDeclarationsConnectorMock
-    val submissionRepositoryMock: SubmissionRepository = buildSubmissionRepositoryMock
-    val declarationRepositoryMock: DeclarationRepository = mock[DeclarationRepository]
-    val notificationRepositoryMock: NotificationRepository = buildNotificationRepositoryMock
-    val metaDataBuilder: MetaDataBuilder = mock[MetaDataBuilder]
-    val wcoMapperService: WcoMapperService = mock[WcoMapperService]
-    val submissionService = new SubmissionService(
-      customsDeclarationsConnector = customsDeclarationsConnectorMock,
-      submissionRepository = submissionRepositoryMock,
-      declarationRepository = declarationRepositoryMock,
-      notificationRepository = notificationRepositoryMock,
-      metaDataBuilder = injector.getInstance(classOf[MetaDataBuilder]),
-      wcoMapperService = injector.getInstance(classOf[WcoMapperService])
-    )(ExecutionContext.global)
+  override def afterEach(): Unit = {
+    reset(customsDeclarationsConnector, submissionRepository, declarationRepository, notificationRepository, metaDataBuilder, wcoMapperService)
+    super.afterEach()
   }
 
   "cancel" should {
@@ -82,33 +72,32 @@ class SubmissionServiceSpec
     val cancellation = SubmissionCancellation("ref-id", "mrn", "description", "reason")
 
     "submit and delegate to repository" when {
-      "submission exists" in new Test {
+      "submission exists" in {
         when(metaDataBuilder.buildRequest(any(), any(), any(), any(), any())).thenReturn(mock[MetaData])
         when(wcoMapperService.toXml(any())).thenReturn("xml")
-        when(customsDeclarationsConnectorMock.submitCancellation(any(), any())(any()))
-          .thenReturn(Future.successful("conv-id"))
-        when(submissionRepositoryMock.findSubmissionByMrn(any())).thenReturn(Future.successful(Some(submission)))
-        when(submissionRepositoryMock.addAction(any[String](), any())).thenReturn(Future.successful(Some(submission)))
+        when(customsDeclarationsConnector.submitCancellation(any(), any())(any())).thenReturn(Future.successful("conv-id"))
+        when(submissionRepository.findSubmissionByMrn(any())).thenReturn(Future.successful(Some(submission)))
+        when(submissionRepository.addAction(any[String](), any())).thenReturn(Future.successful(Some(submission)))
 
         submissionService.cancel("eori", cancellation).futureValue mustBe CancellationRequested
       }
 
-      "submission is missing" in new Test {
+      "submission is missing" in {
         when(metaDataBuilder.buildRequest(any(), any(), any(), any(), any())).thenReturn(mock[MetaData])
         when(wcoMapperService.toXml(any())).thenReturn("xml")
-        when(customsDeclarationsConnectorMock.submitCancellation(any(), any())(any()))
+        when(customsDeclarationsConnector.submitCancellation(any(), any())(any()))
           .thenReturn(Future.successful("conv-id"))
-        when(submissionRepositoryMock.findSubmissionByMrn(any())).thenReturn(Future.successful(None))
+        when(submissionRepository.findSubmissionByMrn(any())).thenReturn(Future.successful(None))
 
         submissionService.cancel("eori", cancellation).futureValue mustBe MissingDeclaration
       }
 
-      "submission exists and previously cancelled" in new Test {
+      "submission exists and previously cancelled" in {
         when(metaDataBuilder.buildRequest(any(), any(), any(), any(), any())).thenReturn(mock[MetaData])
         when(wcoMapperService.toXml(any())).thenReturn("xml")
-        when(customsDeclarationsConnectorMock.submitCancellation(any(), any())(any()))
+        when(customsDeclarationsConnector.submitCancellation(any(), any())(any()))
           .thenReturn(Future.successful("conv-id"))
-        when(submissionRepositoryMock.findSubmissionByMrn(any()))
+        when(submissionRepository.findSubmissionByMrn(any()))
           .thenReturn(Future.successful(Some(submissionCancelled)))
 
         submissionService.cancel("eori", cancellation).futureValue mustBe CancellationRequestExists
@@ -116,143 +105,152 @@ class SubmissionServiceSpec
     }
   }
 
-  "submit" when {
-    val declaration = aDeclaration(
-      withConsignmentReferences(),
-      withDestinationCountries(),
-      withGoodsLocation(GoodsLocation("PL", "type", "id", Some("a"), Some("b"), Some("c"), Some("d"), Some("e"))),
-      withWarehouseIdentification(Some("a"), Some("b"), Some("c"), Some("d")),
-      withOfficeOfExit("id", Some("office"), Some("code")),
-      withContainerData(TransportInformationContainer("id", Seq.empty)),
-      withTotalNumberOfItems(Some("123"), Some("123")),
-      withNatureOfTransaction("nature"),
-      withItems(3)
-    )
-    "request to upstream service is successful" should {
-
-      "create request submission action" in new Test {
-        def theActionAdded: Action = {
-          val captor: ArgumentCaptor[Action] = ArgumentCaptor.forClass(classOf[Action])
-          verify(submissionRepositoryMock).addAction(meq(firstSubmission), captor.capture())
-          captor.getValue
-        }
-
-        def theDeclarationUpdated: ExportsDeclaration = {
-          val captor: ArgumentCaptor[ExportsDeclaration] = ArgumentCaptor.forClass(classOf[ExportsDeclaration])
-          verify(declarationRepositoryMock).update(captor.capture())
-          captor.getValue
-        }
-
-        val conversationId = UUID.randomUUID().toString
-        private val firstSubmission: Submission = mock[Submission]
-        when(submissionRepositoryMock.findOrCreate(any(), any(), any())).thenReturn(Future.successful(firstSubmission))
-        when(declarationRepositoryMock.update(any())).thenReturn(Future.successful(Some(declaration)))
-        when(customsDeclarationsConnectorMock.submitDeclaration(any(), any())(any()))
-          .thenReturn(Future.successful(conversationId))
-        when(submissionRepositoryMock.addAction(any[Submission](), any()))
-          .thenReturn(Future.successful(mock[Submission]))
-
-        val submission = submissionService.submit(declaration).futureValue
-
-        val action = theActionAdded
-        action.id mustEqual conversationId
-        action.requestType mustEqual SubmissionRequest
-        theDeclarationUpdated.status mustEqual DeclarationStatus.COMPLETE
-      }
-    }
-    "request to upstream service failed" should {
-      "keep action list empty" in new Test {
-        private val firstSubmission: Submission = mock[Submission]
-        when(submissionRepositoryMock.findOrCreate(any(), any(), any())).thenReturn(Future.successful(firstSubmission))
-        when(customsDeclarationsConnectorMock.submitDeclaration(any(), any())(any()))
-          .thenReturn(Future.failed(new Exception()))
-        when(submissionRepositoryMock.addAction(any[Submission](), any()))
-          .thenReturn(Future.successful(mock[Submission]))
-
-        Await.ready(submissionService.submit(declaration), patienceConfig.timeout)
-
-        verify(submissionRepositoryMock, never()).addAction(any[Submission](), any())
-        verify(declarationRepositoryMock, never()).update(any())
-      }
+  "submit" should {
+    def theActionAdded(): Action = {
+      val captor: ArgumentCaptor[Action] = ArgumentCaptor.forClass(classOf[Action])
+      verify(submissionRepository).addAction(any[Submission](), captor.capture())
+      captor.getValue
     }
 
-    "there are notification with conversation id" should {
-      "update submission with linked mrn" in new Test {
-        val conversationId = UUID.randomUUID().toString
-        private val firstSubmission: Submission = mock[Submission]
-        when(submissionRepositoryMock.findOrCreate(any(), any(), any())).thenReturn(Future.successful(firstSubmission))
-        when(customsDeclarationsConnectorMock.submitDeclaration(any(), any())(any()))
-          .thenReturn(Future.successful(conversationId))
-        when(declarationRepositoryMock.update(any())).thenReturn(Future.successful(Some(declaration)))
-        when(submissionRepositoryMock.addAction(any[Submission](), any()))
-          .thenReturn(Future.successful(firstSubmission))
+    def theDeclarationUpdated(index: Int = 0): ExportsDeclaration = {
+      val captor: ArgumentCaptor[ExportsDeclaration] = ArgumentCaptor.forClass(classOf[ExportsDeclaration])
+      verify(declarationRepository, atLeastOnce()).update(captor.capture())
+      captor.getAllValues.get(index)
+    }
 
-        private val notification: Notification = NotificationTestData.exampleNotification(conversationId)
-        private val notifications: Seq[Notification] = Seq(notification)
-        when(notificationRepositoryMock.findNotificationsByActionId(conversationId))
-          .thenReturn(Future.successful(notifications))
+    def theSubmissionCreated(): Submission = {
+      val captor: ArgumentCaptor[Submission] = ArgumentCaptor.forClass(classOf[Submission])
+      verify(submissionRepository).findOrCreate(any(), any(), captor.capture())
+      captor.getValue
+    }
 
-        submissionService.submit(declaration).futureValue
+    "submit to the Dec API" when {
+      val declaration = aDeclaration()
+      val notification = Notification("id", "mrn", LocalDateTime.now(), SubmissionStatus.ACCEPTED, Seq.empty, "xml")
+      val submission = Submission(declaration, "lrn", "mrn")
 
-        eventually {
-          verify(submissionRepositoryMock).updateMrn(conversationId, notification.mrn)
+      "valid declaration" in {
+        // Given
+        when(wcoMapperService.produceMetaData(any())).thenReturn(mock[MetaData])
+        when(wcoMapperService.declarationLrn(any())).thenReturn(Some("lrn"))
+        when(wcoMapperService.declarationDucr(any())).thenReturn(Some("ducr"))
+        when(wcoMapperService.toXml(any())).thenReturn("xml")
+        when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
+        when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
+        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any())).thenReturn(Future.successful("conv-id"))
+        when(submissionRepository.addAction(any[Submission](), any())).thenReturn(Future.successful(submission))
+        when(notificationRepository.findNotificationsByActionId(anyString())).thenReturn(Future.successful(Seq.empty))
+
+        // When
+        submissionService.submit(declaration).futureValue mustBe submission
+
+        // Then
+        theSubmissionCreated() mustBe Submission(declaration, "lrn", "ducr")
+
+        val action = theActionAdded()
+        action.id mustBe "conv-id"
+        action.requestType mustBe SubmissionRequest
+
+        theDeclarationUpdated().status mustEqual DeclarationStatus.COMPLETE
+      }
+
+      "existing notification is available" in {
+        // Given
+        when(wcoMapperService.produceMetaData(any())).thenReturn(mock[MetaData])
+        when(wcoMapperService.declarationLrn(any())).thenReturn(Some("lrn"))
+        when(wcoMapperService.declarationDucr(any())).thenReturn(Some("ducr"))
+        when(wcoMapperService.toXml(any())).thenReturn("xml")
+        when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
+        when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
+        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any())).thenReturn(Future.successful("conv-id"))
+        when(submissionRepository.addAction(any[Submission](), any())).thenReturn(Future.successful(mock[Submission]))
+        when(notificationRepository.findNotificationsByActionId(anyString())).thenReturn(Future.successful(Seq(notification)))
+        when(submissionRepository.updateMrn(any(), any())).thenReturn(Future.successful(Some(submission)))
+
+        // When
+        submissionService.submit(declaration).futureValue mustBe submission
+
+        // Then
+        theSubmissionCreated() mustBe Submission(declaration, "lrn", "ducr")
+
+        val action = theActionAdded()
+        action.id mustBe "conv-id"
+        action.requestType mustBe SubmissionRequest
+
+        theDeclarationUpdated().status mustEqual DeclarationStatus.COMPLETE
+      }
+    }
+
+    "revert declaration to draft" when {
+      "submission to the Dec API fails" in {
+        // Given
+        when(wcoMapperService.produceMetaData(any())).thenReturn(mock[MetaData])
+        when(wcoMapperService.declarationLrn(any())).thenReturn(Some("lrn"))
+        when(wcoMapperService.declarationDucr(any())).thenReturn(Some("ducr"))
+        when(wcoMapperService.toXml(any())).thenReturn("xml")
+        when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
+        when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
+        when(customsDeclarationsConnector.submitDeclaration(any(), any())(any())).thenReturn(Future.failed(new RuntimeException("Some error")))
+
+        val declaration = aDeclaration()
+
+        // When
+        intercept[RuntimeException] {
+          submissionService.submit(declaration).futureValue
+        }
+
+        // Then
+        theSubmissionCreated() mustBe Submission(declaration, "lrn", "ducr")
+
+        verify(submissionRepository, never()).addAction(any[Submission], any[Action])
+
+        theDeclarationUpdated(0).status mustEqual DeclarationStatus.COMPLETE
+        theDeclarationUpdated(1).status mustEqual DeclarationStatus.DRAFT
+      }
+    }
+
+    "throw exception" when {
+      "missing LRN" in {
+        when(wcoMapperService.produceMetaData(any())).thenReturn(mock[MetaData])
+        when(wcoMapperService.declarationLrn(any())).thenReturn(None)
+        when(wcoMapperService.declarationDucr(any())).thenReturn(Some("ducr"))
+
+        intercept[IllegalArgumentException] {
+          submissionService.submit(aDeclaration()).futureValue
+        }
+      }
+
+      "missing DUCR" in {
+        when(wcoMapperService.produceMetaData(any())).thenReturn(mock[MetaData])
+        when(wcoMapperService.declarationLrn(any())).thenReturn(Some("lrn"))
+        when(wcoMapperService.declarationDucr(any())).thenReturn(None)
+
+        intercept[IllegalArgumentException] {
+          submissionService.submit(aDeclaration()).futureValue
         }
       }
     }
   }
 
-  "SubmissionService on getAllSubmissionsForUser" should {
+  "Get all Submissions for eori" should {
+    "delegate to repository" in {
+      val response = mock[Seq[Submission]]
+      when(submissionRepository.findAllSubmissionsForEori(any())).thenReturn(Future.successful(response))
 
-    "return empty list if SubmissionRepository does not find any Submission" in new Test {
-      submissionService.getAllSubmissionsForUser(eori).futureValue must equal(Seq.empty)
-    }
+      submissionService.getAllSubmissionsForUser(eori).futureValue mustBe response
 
-    "return all submissions returned by SubmissionRepository" in new Test {
-      when(submissionRepositoryMock.findAllSubmissionsForEori(meq(eori)))
-        .thenReturn(Future.successful(Seq(submission, submission_2)))
-
-      val returnedSubmissions = submissionService.getAllSubmissionsForUser(eori).futureValue
-
-      returnedSubmissions.size must equal(2)
-      returnedSubmissions must contain(submission)
-      returnedSubmissions must contain(submission_2)
-    }
-
-    "call SubmissionRepository.findAllSubmissionsForUser, passing EORI provided" in new Test {
-      submissionService.getAllSubmissionsForUser(eori).futureValue
-
-      verify(submissionRepositoryMock, times(1)).findAllSubmissionsForEori(meq(eori))
+      verify(submissionRepository).findAllSubmissionsForEori(meq(eori))
     }
   }
 
-  "SubmissionService on getSubmission" should {
+  "Get Submission" should {
+    "delegate to repository" in {
+      val response = mock[Option[Submission]]
+      when(submissionRepository.findSubmissionByUuid(any(), any())).thenReturn(Future.successful(response))
 
-    "return empty Option if SubmissionRepository does not find any Submission" in new Test {
-      submissionService.getSubmission(eori, uuid).futureValue must equal(None)
-    }
+      submissionService.getSubmission(eori, uuid).futureValue mustBe response
 
-    "return submission returned by SubmissionRepository" in new Test {
-      when(submissionRepositoryMock.findSubmissionByUuid(meq(eori), meq(uuid)))
-        .thenReturn(Future.successful(Some(submission)))
-
-      val returnedSubmission = submissionService.getSubmission(eori, uuid).futureValue
-
-      returnedSubmission must be(defined)
-      returnedSubmission.get must equal(submission)
-    }
-
-    "call SubmissionRepository.findSubmissionByUuid, passing UUID provided" in new Test {
-      submissionService.getSubmission(eori, uuid).futureValue
-
-      verify(submissionRepositoryMock, times(1)).findSubmissionByUuid(meq(eori), meq(uuid))
+      verify(submissionRepository).findSubmissionByUuid(meq(eori), meq(uuid))
     }
   }
-}
-
-object SubmissionServiceSpec {
-  val validatedHeadersSubmissionRequest: SubmissionRequestHeaders =
-    SubmissionRequestHeaders(LocalReferenceNumber(lrn), Some(ducr))
-
-  val submissionXml: NodeSeq = <submissionXml></submissionXml>
-  val cancellationXml: NodeSeq = <cancellationXml></cancellationXml>
 }


### PR DESCRIPTION
Hopefully helps reduce the duplicate DMS submissions we are seeing in QA
- We only mark the dec as COMPLETE once it has submitted to DMS successfully
- If the DMS call fails we keep it as a draft