### PR TITLE
CEDS-1404 Remove obsolete fields reference-part from produce documents

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
@@ -98,11 +98,6 @@ object AdditionalInformations {
   implicit val format: OFormat[AdditionalInformations] = Json.format[AdditionalInformations]
 }
 
-case class DocumentIdentifierAndPart(documentIdentifier: Option[String], documentPart: Option[String])
-object DocumentIdentifierAndPart {
-  implicit val format: OFormat[DocumentIdentifierAndPart] = Json.format[DocumentIdentifierAndPart]
-}
-
 case class Date(day: Option[Int], month: Option[Int], year: Option[Int]) {
   def toLocalDate: LocalDate = LocalDate.of(year.getOrElse(0), month.getOrElse(0), day.getOrElse(0))
 }
@@ -117,7 +112,7 @@ object DocumentWriteOff {
 
 case class DocumentProduced(
   documentTypeCode: Option[String],
-  documentIdentifierAndPart: Option[DocumentIdentifierAndPart],
+  documentIdentifier: Option[String],
   documentStatus: Option[String],
   documentStatusReason: Option[String],
   issuingAuthorityName: Option[String],

--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilder.scala
@@ -159,7 +159,7 @@ object AdditionalDocumentsBuilder {
     GovernmentAgencyGoodsItemAdditionalDocument(
       categoryCode = doc.documentTypeCode.map(_.substring(0, 1)),
       typeCode = doc.documentTypeCode.map(_.substring(1)),
-      id = createAdditionalDocumentId(doc),
+      id = doc.documentIdentifier,
       lpcoExemptionCode = doc.documentStatus,
       name = doc.documentStatusReason,
       submitter =
@@ -176,13 +176,6 @@ object AdditionalDocumentsBuilder {
         ),
       writeOff = createAdditionalDocumentWriteOff(doc)
     )
-
-  private def createAdditionalDocumentId(doc: DocumentProduced): Option[String] =
-    for {
-      documentIdentifierAndPart <- doc.documentIdentifierAndPart
-      documentIdentifier <- documentIdentifierAndPart.documentIdentifier
-      documentPart <- documentIdentifierAndPart.documentPart
-    } yield documentIdentifier + documentPart
 
   private def createAdditionalDocumentWriteOff(doc: DocumentProduced): Option[WriteOff] =
     for {

--- a/test/integration/uk/gov/hmrc/exports/repositories/DeclarationRepositoryTest.scala
+++ b/test/integration/uk/gov/hmrc/exports/repositories/DeclarationRepositoryTest.scala
@@ -44,8 +44,8 @@ class DeclarationRepositoryTest
 
   private val repository = injector.instanceOf[DeclarationRepository]
 
-  override def afterEach(): Unit = {
-    super.afterEach()
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     repository.removeAll().futureValue
   }
 

--- a/test/integration/uk/gov/hmrc/exports/repositories/NotificationRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/repositories/NotificationRepositorySpec.scala
@@ -44,8 +44,8 @@ class NotificationRepositorySpec
 
   implicit val ec: ExecutionContext = global
 
-  override def afterEach(): Unit = {
-    super.afterEach()
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     repo.removeAll().futureValue
   }
 

--- a/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
+++ b/test/integration/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
@@ -47,9 +47,9 @@ class SubmissionRepositorySpec
 
   implicit val ec: ExecutionContext = global
 
-  override def afterEach(): Unit = {
+  override def beforeEach(): Unit = {
+    super.beforeEach()
     repo.removeAll().futureValue
-    super.afterEach()
   }
 
   "Submission Repository on save" when {

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
 
 import org.scalatest.{Matchers, WordSpec}
-import uk.gov.hmrc.exports.models.declaration.{Date, DocumentIdentifierAndPart, DocumentProduced}
+import uk.gov.hmrc.exports.models.declaration.{Date, DocumentProduced}
 import uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem.AdditionalDocumentsBuilder
 import uk.gov.hmrc.wco.dec._
 
@@ -60,7 +60,7 @@ class AdditionalDocumentsBuilderSpec extends WordSpec with Matchers with Governm
     "map DocumentProduced to GovernmentAgencyGoodsItemAdditionalDocument" in {
       val doc = DocumentProduced(
         documentTypeCode = Some("DOC"),
-        documentIdentifierAndPart = Some(DocumentIdentifierAndPart(Some("id"), Some("part"))),
+        documentIdentifier = Some("idpart"),
         documentStatus = Some("status"),
         documentStatusReason = Some("reason"),
         issuingAuthorityName = Some("issuingAuthority"),

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
@@ -90,9 +90,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
     correctDocumentsProducedData: DocumentsProduced
   ) {
     val document = correctDocumentsProducedData.documents.head
-    val documentIdentifierAndPart = document.documentIdentifierAndPart.get
-    val identifier = documentIdentifierAndPart.documentIdentifier.getOrElse("") + documentIdentifierAndPart.documentPart
-      .getOrElse("")
+    val identifier = document.documentIdentifier.getOrElse("")
 
     validateAdditionalDocument(
       firstMappedDocument = mappedDocument,

--- a/test/util/SeedMongo.scala
+++ b/test/util/SeedMongo.scala
@@ -77,7 +77,7 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
         withDocumentsProduced(
           DocumentProduced(
             Some("C501"),
-            Some(DocumentIdentifierAndPart(Some("GBAEOC71757250450281"), Some("1"))),
+            Some("GBAEOC71757250450281"),
             None,
             None,
             None,

--- a/test/util/SeedMongo.scala
+++ b/test/util/SeedMongo.scala
@@ -75,15 +75,7 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
         withCommodityMeasure(CommodityMeasure(Some("10"), "500", "700")),
         withAdditionalInformation("00400", "EXPORTER"),
         withDocumentsProduced(
-          DocumentProduced(
-            Some("C501"),
-            Some("GBAEOC71757250450281"),
-            None,
-            None,
-            None,
-            None,
-            None
-          )
+          DocumentProduced(Some("C501"), Some("GBAEOC71757250450281"), None, None, None, None, None)
         )
       )
     ),


### PR DESCRIPTION
Now it merged with document identifier as single field

Related to https://github.com/hmrc/customs-declare-exports-frontend/pull/548