### PR TITLE
CEDS-1695 Fix for Pointer Fields that have numeric codes

### DIFF
--- a/app/uk/gov/hmrc/exports/models/Pointer.scala
+++ b/app/uk/gov/hmrc/exports/models/Pointer.scala
@@ -25,8 +25,7 @@ import scala.util.{Success, Try}
 object PointerSectionType extends Enumeration {
   type PointerSectionType = Value
   val FIELD, SEQUENCE = Value
-  implicit val format: Format[models.PointerSectionType.Value] =
-    Format(Reads.enumNameReads(PointerSectionType), Writes.enumNameWrites)
+  implicit val format: Format[models.PointerSectionType.Value] = Format(Reads.enumNameReads(PointerSectionType), Writes.enumNameWrites)
 }
 
 case class PointerSection(value: String, `type`: PointerSectionType) {
@@ -34,10 +33,22 @@ case class PointerSection(value: String, `type`: PointerSectionType) {
     case PointerSectionType.FIELD    => value
     case PointerSectionType.SEQUENCE => "$"
   }
+
+  override def toString: String = `type` match {
+    case PointerSectionType.FIELD    => value
+    case PointerSectionType.SEQUENCE => "#" + value
+  }
 }
 
 object PointerSection {
-  implicit val format = Json.format[PointerSection]
+  private val SEQUENCE_REGEX = "^#(\\d*)$".r
+  implicit val format: Format[PointerSection] =
+    Format[PointerSection](Reads(js => js.validate[String].map(PointerSection(_))), Writes(section => JsString(section.toString)))
+
+  def apply(value: String): PointerSection = SEQUENCE_REGEX.findFirstMatchIn(value).map(_.group(1)) match {
+    case Some(sequence) => PointerSection(sequence, PointerSectionType.SEQUENCE)
+    case _              => PointerSection(value, PointerSectionType.FIELD)
+  }
 }
 
 case class Pointer(sections: Seq[PointerSection]) {
@@ -46,24 +57,17 @@ case class Pointer(sections: Seq[PointerSection]) {
   // e.g. ABC.DEF.GHI (if the pointer doesnt contain a sequence)
   lazy val pattern: PointerPattern = PointerPattern(sections.map(_.pattern).mkString("."))
 
-  // Converts a pointer into its value form
-  // e.g. ABC.DEF.1.GHI  (if the pointer contains a sequence with index 1)
+  // Converts a pointer to it's string form preserving the type
+  // e.g. ABC.DEF.#1.GHI (if the pointer contains a sequence with index 1)
   // e.g. ABC.DEF.GHI (if the pointer doesnt contain a sequence)
-  lazy val value: String = sections.map(_.value).mkString(".")
-  override def toString: String = value
+  override def toString: String = sections.map(_.toString).mkString(".")
 }
 
 object Pointer {
   implicit val format: Format[Pointer] =
     Format(Reads(js => js.validate[JsString].map(string => Pointer(string.value))), Writes(pointer => JsString(pointer.toString)))
 
-  def apply(sections: String): Pointer =
-    Pointer(sections.split("\\.").map { section =>
-      Try(section.toInt) match {
-        case Success(_) => PointerSection(section, PointerSectionType.SEQUENCE)
-        case _          => PointerSection(section, PointerSectionType.FIELD)
-      }
-    })
+  def apply(sections: String): Pointer = Pointer(sections.split("\\.").map(PointerSection(_)))
 }
 
 case class PointerPattern(sections: List[PointerPatternSection]) {

--- a/app/uk/gov/hmrc/exports/models/Pointer.scala
+++ b/app/uk/gov/hmrc/exports/models/Pointer.scala
@@ -65,7 +65,7 @@ case class Pointer(sections: Seq[PointerSection]) {
 
 object Pointer {
   implicit val format: Format[Pointer] =
-    Format(Reads(js => js.validate[JsString].map(string => Pointer(string.value))), Writes(pointer => JsString(pointer.toString)))
+    Format(Reads(js => js.validate[String].map(Pointer(_))), Writes(pointer => JsString(pointer.toString)))
 
   def apply(sections: String): Pointer = Pointer(sections.split("\\.").map(PointerSection(_)))
 }

--- a/test/uk/gov/hmrc/exports/models/PointerSpec.scala
+++ b/test/uk/gov/hmrc/exports/models/PointerSpec.scala
@@ -36,40 +36,44 @@ class PointerSpec extends WordSpec with MustMatchers {
       sequence.pattern mustBe "$"
     }
 
-    "map field to value" in {
-      field.value mustBe "ABC"
+    "map field to string" in {
+      field.toString mustBe "ABC"
     }
 
-    "map sequence to value" in {
-      sequence.value mustBe "123"
+    "map sequence to string" in {
+      sequence.toString mustBe "#123"
+    }
+
+    "map field from string" in {
+      PointerSection("ABC") mustBe field
+    }
+
+    "map sequence from string" in {
+      PointerSection("#123") mustBe sequence
     }
   }
 
   "Pointer" should {
     val field1 = PointerSection("ABC", PointerSectionType.FIELD)
     val sequence1 = PointerSection("123", PointerSectionType.SEQUENCE)
-    val field2 = PointerSection("DEF", PointerSectionType.FIELD)
+    val field2 = PointerSection("000", PointerSectionType.FIELD)
     val sequence2 = PointerSection("321", PointerSectionType.SEQUENCE)
     val pointer = Pointer(List(field1, sequence1, field2, sequence2))
 
     "map to pattern" in {
-      pointer.pattern mustBe PointerPattern(List("ABC", "$", "DEF", "$"))
-    }
-
-    "map to value" in {
-      pointer.value mustBe "ABC.123.DEF.321"
+      pointer.pattern mustBe PointerPattern(List("ABC", "$", "000", "$"))
     }
 
     "map to string" in {
-      pointer.toString mustBe "ABC.123.DEF.321"
+      pointer.toString mustBe "ABC.#123.000.#321"
     }
 
     "serialize to JSON" in {
-      Json.toJson(pointer)(Pointer.format) mustBe JsString("ABC.123.DEF.321")
+      Json.toJson(pointer)(Pointer.format) mustBe JsString("ABC.#123.000.#321")
     }
 
     "deserialize from JSON" in {
-      Json.fromJson(JsString("ABC.123.DEF.321"))(Pointer.format) mustBe JsSuccess(pointer)
+      Json.fromJson(JsString("ABC.#123.000.#321"))(Pointer.format) mustBe JsSuccess(pointer)
     }
   }
 

--- a/test/uk/gov/hmrc/exports/services/WCOPointerMappingServiceSpec.scala
+++ b/test/uk/gov/hmrc/exports/services/WCOPointerMappingServiceSpec.scala
@@ -34,7 +34,7 @@ class WCOPointerMappingServiceSpec extends WordSpec with MustMatchers with Mocki
 
   "Map pointer" should {
     "find matching pointer" in {
-      given(fileReader.readLines(anyString())).willReturn(List("a.b, x.y"))
+      given(fileReader.readLines(anyString(), anyBoolean())).willReturn(List("a.b, x.y"))
 
       val pointer =
         Pointer(List(PointerSection("a", PointerSectionType.FIELD), PointerSection("b", PointerSectionType.FIELD)))
@@ -45,7 +45,7 @@ class WCOPointerMappingServiceSpec extends WordSpec with MustMatchers with Mocki
     }
 
     "not find missing pointer" in {
-      given(fileReader.readLines(anyString())).willReturn(List("a.b, x.y"))
+      given(fileReader.readLines(anyString(), anyBoolean())).willReturn(List("a.b, x.y"))
 
       val pointer =
         Pointer(List(PointerSection("x", PointerSectionType.FIELD), PointerSection("x", PointerSectionType.FIELD)))


### PR DESCRIPTION
We used to have a custom json formatter that assumed that because a pointer section was numerical, then it represented a sequence index. This is not the case, some pointer field references are purely numerical and we need to handle that.

Sequence sections are now rendered in JSON as `#1` (for index 1)
e.g.
Pointer Before: `abc.1.def`
Pointer After: `abc.#1.def`

It means we can convert to and from the string/json version and retain the "section type"