### PR TITLE
CEDS-1839 Permit Simplified Declarations

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequest.scala
+++ b/app/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequest.scala
@@ -21,6 +21,7 @@ import java.time.Instant
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.exports.models.DeclarationType.DeclarationType
 import uk.gov.hmrc.exports.models.Eori
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AdditionalDeclarationType
 import uk.gov.hmrc.exports.models.declaration._
 
 case class ExportsDeclarationRequest(

--- a/app/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationType.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationType.scala
@@ -16,15 +16,21 @@
 
 package uk.gov.hmrc.exports.models.declaration
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json._
 
-case class AdditionalDeclarationType(additionalDeclarationType: String)
-
-object AdditionalDeclarationType {
-  implicit val format: OFormat[AdditionalDeclarationType] = Json.format[AdditionalDeclarationType]
-
-  object AllowedAdditionalDeclarationTypes {
-    val Simplified = "Y"
-    val Standard = "Z"
-  }
+object AdditionalDeclarationType extends Enumeration {
+  type AdditionalDeclarationType = Value
+  implicit val format: Format[AdditionalDeclarationType.Value] =
+    Format(
+      Reads(
+        _.validate[String]
+          .filter(s => AdditionalDeclarationType.values.exists(_.toString == s))
+          .map(s => AdditionalDeclarationType.values.find(_.toString == s).get)
+      ),
+      Writes(v => JsString(v.toString))
+    )
+  val SUPPLEMENTARY_SIMPLIFIED = Value("Y")
+  val SUPPLEMENTARY_EIDR = Value("Z")
+  val STANDARD_PRE_LODGED = Value("D")
+  val STANDARD_FRONTIER = Value("A")
 }

--- a/app/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationType.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationType.scala
@@ -24,8 +24,8 @@ object AdditionalDeclarationType extends Enumeration {
     Format(
       Reads(
         _.validate[String]
-          .filter(s => AdditionalDeclarationType.values.exists(_.toString == s))
-          .map(s => AdditionalDeclarationType.values.find(_.toString == s).get)
+          .filter(JsError("Invalid AdditionalDeclarationType"))(value => AdditionalDeclarationType.values.exists(_.toString == value))
+          .map(value => AdditionalDeclarationType.values.find(_.toString == value).get)
       ),
       Writes(v => JsString(v.toString))
     )

--- a/app/uk/gov/hmrc/exports/models/declaration/ExportsDeclaration.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportsDeclaration.scala
@@ -20,6 +20,7 @@ import java.time.Instant
 
 import play.api.libs.json._
 import uk.gov.hmrc.exports.models.DeclarationType.DeclarationType
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AdditionalDeclarationType
 import uk.gov.hmrc.exports.models.declaration.DeclarationStatus.DeclarationStatus
 
 case class ExportsDeclaration(

--- a/app/uk/gov/hmrc/exports/services/SubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/SubmissionService.scala
@@ -33,12 +33,12 @@ import scala.util.{Failure, Success}
 
 @Singleton
 class SubmissionService @Inject()(
-                                   customsDeclarationsConnector: CustomsDeclarationsConnector,
-                                   submissionRepository: SubmissionRepository,
-                                   declarationRepository: DeclarationRepository,
-                                   notificationRepository: NotificationRepository,
-                                   metaDataBuilder: CancellationMetaDataBuilder,
-                                   wcoMapperService: WcoMapperService
+  customsDeclarationsConnector: CustomsDeclarationsConnector,
+  submissionRepository: SubmissionRepository,
+  declarationRepository: DeclarationRepository,
+  notificationRepository: NotificationRepository,
+  metaDataBuilder: CancellationMetaDataBuilder,
+  wcoMapperService: WcoMapperService
 )(implicit executionContext: ExecutionContext) {
 
   private val logger = Logger(classOf[SubmissionService])

--- a/app/uk/gov/hmrc/exports/services/SubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/SubmissionService.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclara
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.models.declaration.submissions._
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
-import uk.gov.hmrc.exports.services.mapping.MetaDataBuilder
+import uk.gov.hmrc.exports.services.mapping.CancellationMetaDataBuilder
 import uk.gov.hmrc.http.HeaderCarrier
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
 
@@ -33,12 +33,12 @@ import scala.util.{Failure, Success}
 
 @Singleton
 class SubmissionService @Inject()(
-  customsDeclarationsConnector: CustomsDeclarationsConnector,
-  submissionRepository: SubmissionRepository,
-  declarationRepository: DeclarationRepository,
-  notificationRepository: NotificationRepository,
-  metaDataBuilder: MetaDataBuilder,
-  wcoMapperService: WcoMapperService
+                                   customsDeclarationsConnector: CustomsDeclarationsConnector,
+                                   submissionRepository: SubmissionRepository,
+                                   declarationRepository: DeclarationRepository,
+                                   notificationRepository: NotificationRepository,
+                                   metaDataBuilder: CancellationMetaDataBuilder,
+                                   wcoMapperService: WcoMapperService
 )(implicit executionContext: ExecutionContext) {
 
   private val logger = Logger(classOf[SubmissionService])

--- a/app/uk/gov/hmrc/exports/services/mapping/CancellationMetaDataBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/CancellationMetaDataBuilder.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.exports.services.mapping.declaration.DeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
 
-class MetaDataBuilder @Inject()(declarationBuilder: DeclarationBuilder) {
+class CancellationMetaDataBuilder @Inject()(declarationBuilder: DeclarationBuilder) {
 
   def buildRequest(functionalReferenceId: String, mrn: String, statementDescription: String, changeReason: String, eori: String): MetaData = {
     val metaData = new MetaData

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilder.scala
@@ -26,7 +26,7 @@ import wco.datamodel.wco.declaration_ds.dms._2._
 
 class ExitOfficeBuilder @Inject()() extends ModifyingBuilder[ExportsDeclaration, Declaration] {
   override def buildThenAdd(model: ExportsDeclaration, declaration: Declaration): Unit = model.`type` match {
-    case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY =>
+    case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY | DeclarationType.SIMPLIFIED =>
       model.locations.officeOfExit
         .map(build)
         .foreach(declaration.setExitOffice)

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilder.scala
@@ -32,7 +32,7 @@ class PresentationOfficeBuilder @Inject()() extends ModifyingBuilder[ExportsDecl
           .flatMap(_.presentationOfficeId)
           .map(createPresentationOffice)
           .foreach(declaration.setPresentationOffice)
-      case _ =>
+      case _ => (): Unit
     }
 
   private def createPresentationOffice(value: String): Declaration.PresentationOffice = {

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilder.scala
@@ -26,11 +26,13 @@ import wco.datamodel.wco.declaration_ds.dms._2._
 
 class PresentationOfficeBuilder @Inject()() extends ModifyingBuilder[ExportsDeclaration, Declaration] {
   override def buildThenAdd(model: ExportsDeclaration, declaration: Declaration): Unit =
-    if (model.`type`.equals(DeclarationType.STANDARD)) {
-      model.locations.officeOfExit
-        .flatMap(_.presentationOfficeId)
-        .map(createPresentationOffice)
-        .foreach(declaration.setPresentationOffice)
+    model.`type` match {
+      case DeclarationType.STANDARD | DeclarationType.SIMPLIFIED =>
+        model.locations.officeOfExit
+          .flatMap(_.presentationOfficeId)
+          .map(createPresentationOffice)
+          .foreach(declaration.setPresentationOffice)
+      case _ =>
     }
 
   private def createPresentationOffice(value: String): Declaration.PresentationOffice = {

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilder.scala
@@ -31,7 +31,7 @@ class SpecificCircumstancesCodeBuilder @Inject()() extends ModifyingBuilder[Expo
           .filter(_.circumstancesCode.contains("Yes"))
           .map(_ => createCircumstancesCode)
           .foreach(declaration.setSpecificCircumstancesCodeCode)
-      case _ =>
+      case _ => (): Unit
     }
 
   private def createCircumstancesCode: DeclarationSpecificCircumstancesCodeCodeType = {

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilder.scala
@@ -25,11 +25,13 @@ import wco.datamodel.wco.declaration_ds.dms._2._
 
 class SpecificCircumstancesCodeBuilder @Inject()() extends ModifyingBuilder[ExportsDeclaration, Declaration] {
   override def buildThenAdd(model: ExportsDeclaration, declaration: Declaration): Unit =
-    if (model.`type`.equals(DeclarationType.STANDARD)) {
-      model.locations.officeOfExit
-        .filter(_.circumstancesCode.contains("Yes"))
-        .map(_ => createCircumstancesCode)
-        .foreach(declaration.setSpecificCircumstancesCodeCode)
+    model.`type` match {
+      case DeclarationType.STANDARD | DeclarationType.SIMPLIFIED =>
+        model.locations.officeOfExit
+          .filter(_.circumstancesCode.contains("Yes"))
+          .map(_ => createCircumstancesCode)
+          .foreach(declaration.setSpecificCircumstancesCodeCode)
+      case _ =>
     }
 
   private def createCircumstancesCode: DeclarationSpecificCircumstancesCodeCodeType = {

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/TypeCodeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/TypeCodeBuilder.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.exports.services.mapping.declaration
 
 import javax.inject.Inject
-import uk.gov.hmrc.exports.models.declaration.{AdditionalDeclarationType, DispatchLocation, ExportsDeclaration}
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AdditionalDeclarationType
+import uk.gov.hmrc.exports.models.declaration.{DispatchLocation, ExportsDeclaration}
 import uk.gov.hmrc.exports.services.mapping.ModifyingBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
 import wco.datamodel.wco.declaration_ds.dms._2.DeclarationTypeCodeType
@@ -38,7 +39,7 @@ class TypeCodeBuilder @Inject()() extends ModifyingBuilder[ExportsDeclaration, D
   private def createTypeCode(decType: AdditionalDeclarationType, dispatchLocation: Option[DispatchLocation]): DeclarationTypeCodeType = {
     val typeCodeType = new DeclarationTypeCodeType()
     dispatchLocation.foreach { data =>
-      typeCodeType.setValue(data.dispatchLocation + decType.additionalDeclarationType)
+      typeCodeType.setValue(data.dispatchLocation + decType.toString)
     }
     typeCodeType
   }

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilder.scala
@@ -36,6 +36,6 @@ class DeclarationConsignmentBuilder @Inject()(
         iteneraryBuilder.buildThenAdd(model, consignment)
         consignmentCarrierBuilder.buildThenAdd(model, consignment)
         declaration.setConsignment(consignment)
-      case _ =>
+      case _ => (): Unit
     }
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilder.scala
@@ -29,11 +29,13 @@ class DeclarationConsignmentBuilder @Inject()(
   consignmentCarrierBuilder: ConsignmentCarrierBuilder
 ) extends ModifyingBuilder[ExportsDeclaration, Declaration] {
   override def buildThenAdd(model: ExportsDeclaration, declaration: Declaration): Unit =
-    if (model.`type`.equals(DeclarationType.STANDARD)) {
-      val consignment = new Declaration.Consignment()
-      freightBuilder.buildThenAdd(model, consignment)
-      iteneraryBuilder.buildThenAdd(model, consignment)
-      consignmentCarrierBuilder.buildThenAdd(model, consignment)
-      declaration.setConsignment(consignment)
+    model.`type` match {
+      case DeclarationType.STANDARD | DeclarationType.SIMPLIFIED =>
+        val consignment = new Declaration.Consignment()
+        freightBuilder.buildThenAdd(model, consignment)
+        iteneraryBuilder.buildThenAdd(model, consignment)
+        consignmentCarrierBuilder.buildThenAdd(model, consignment)
+        declaration.setConsignment(consignment)
+      case _ =>
     }
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
@@ -45,7 +45,7 @@ class ConsignmentBuilder @Inject()(
     exportsCacheModel.`type` match {
       case DeclarationType.STANDARD | DeclarationType.SIMPLIFIED =>
         transportEquipmentBuilder.buildThenAdd(exportsCacheModel.containerData.getOrElse(TransportInformationContainers(Seq.empty)), consignment)
-      case _ =>
+      case _ => (): Unit
     }
 
     goodsShipment.setConsignment(consignment)

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
@@ -43,7 +43,7 @@ class ConsignmentBuilder @Inject()(
     )
 
     exportsCacheModel.`type` match {
-      case DeclarationType.STANDARD =>
+      case DeclarationType.STANDARD | DeclarationType.SIMPLIFIED =>
         transportEquipmentBuilder.buildThenAdd(exportsCacheModel.containerData.getOrElse(TransportInformationContainers(Seq.empty)), consignment)
       case _ =>
     }

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentCarrierBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentCarrierBuilder.scala
@@ -35,7 +35,7 @@ class ConsignmentCarrierBuilder @Inject()(countriesService: CountriesService) ex
           .map(_.details)
           .map(buildEoriOrAddress)
           .foreach(consignment.setCarrier)
-      case _ =>
+      case _ => (): Unit
     }
 
   private def isDefined(carrierDetails: CarrierDetails) =

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentCarrierBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentCarrierBuilder.scala
@@ -28,12 +28,14 @@ import wco.datamodel.wco.declaration_ds.dms._2._
 class ConsignmentCarrierBuilder @Inject()(countriesService: CountriesService) extends ModifyingBuilder[ExportsDeclaration, Declaration.Consignment] {
 
   override def buildThenAdd(model: ExportsDeclaration, consignment: Declaration.Consignment): Unit =
-    if (model.`type`.equals(DeclarationType.STANDARD)) {
-      model.parties.carrierDetails
-        .filter(isDefined)
-        .map(_.details)
-        .map(buildEoriOrAddress)
-        .foreach(consignment.setCarrier)
+    model.`type` match {
+      case DeclarationType.STANDARD | DeclarationType.SIMPLIFIED =>
+        model.parties.carrierDetails
+          .filter(isDefined)
+          .map(_.details)
+          .map(buildEoriOrAddress)
+          .foreach(consignment.setCarrier)
+      case _ =>
     }
 
   private def isDefined(carrierDetails: CarrierDetails) =

--- a/test/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
+++ b/test/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
@@ -20,6 +20,7 @@ import java.time.Instant
 
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AdditionalDeclarationType
 import uk.gov.hmrc.exports.models.declaration._
 import uk.gov.hmrc.exports.models.{DeclarationType, Eori}
 import util.testdata.ExportsDeclarationBuilder

--- a/test/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationTypeSpec.scala
+++ b/test/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationTypeSpec.scala
@@ -35,7 +35,7 @@ class AdditionalDeclarationTypeSpec extends WordSpec with MustMatchers {
       Json.fromJson[AdditionalDeclarationType](JsString("D")) mustBe JsSuccess(AdditionalDeclarationType.STANDARD_PRE_LODGED)
       Json.fromJson[AdditionalDeclarationType](JsString("Y")) mustBe JsSuccess(AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED)
       Json.fromJson[AdditionalDeclarationType](JsString("Z")) mustBe JsSuccess(AdditionalDeclarationType.SUPPLEMENTARY_EIDR)
-      Json.fromJson[AdditionalDeclarationType](JsString("other")) mustBe an[JsError]
+      Json.fromJson[AdditionalDeclarationType](JsString("other")) mustBe JsError("Invalid AdditionalDeclarationType")
     }
   }
 

--- a/test/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationTypeSpec.scala
+++ b/test/uk/gov/hmrc/exports/models/declaration/AdditionalDeclarationTypeSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.models.declaration
+
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.libs.json.{JsError, JsString, JsSuccess, Json}
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AdditionalDeclarationType
+
+class AdditionalDeclarationTypeSpec extends WordSpec with MustMatchers {
+
+  "Formatter" should {
+    "map to json" in {
+      Json.toJson(AdditionalDeclarationType.STANDARD_FRONTIER) mustBe JsString("A")
+      Json.toJson(AdditionalDeclarationType.STANDARD_PRE_LODGED) mustBe JsString("D")
+      Json.toJson(AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED) mustBe JsString("Y")
+      Json.toJson(AdditionalDeclarationType.SUPPLEMENTARY_EIDR) mustBe JsString("Z")
+    }
+
+    "map from json" in {
+      Json.fromJson[AdditionalDeclarationType](JsString("A")) mustBe JsSuccess(AdditionalDeclarationType.STANDARD_FRONTIER)
+      Json.fromJson[AdditionalDeclarationType](JsString("D")) mustBe JsSuccess(AdditionalDeclarationType.STANDARD_PRE_LODGED)
+      Json.fromJson[AdditionalDeclarationType](JsString("Y")) mustBe JsSuccess(AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED)
+      Json.fromJson[AdditionalDeclarationType](JsString("Z")) mustBe JsSuccess(AdditionalDeclarationType.SUPPLEMENTARY_EIDR)
+      Json.fromJson[AdditionalDeclarationType](JsString("other")) mustBe an[JsError]
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/exports/services/mapping/CancellationMetaDataBuilderTest.scala
+++ b/test/uk/gov/hmrc/exports/services/mapping/CancellationMetaDataBuilderTest.scala
@@ -25,10 +25,10 @@ import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.services.mapping.declaration.DeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
 
-class MetaDataBuilderTest extends WordSpec with MustMatchers with MockitoSugar {
+class CancellationMetaDataBuilderTest extends WordSpec with MustMatchers with MockitoSugar {
 
   private val declarationBuilder = mock[DeclarationBuilder]
-  private val builder = new MetaDataBuilder(declarationBuilder)
+  private val builder = new CancellationMetaDataBuilder(declarationBuilder)
 
   "Build Request" should {
     val declaration = mock[Declaration]

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.exports.models.declaration.submissions._
 import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration}
 import uk.gov.hmrc.exports.models.{LocalReferenceNumber, SubmissionRequestHeaders}
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
-import uk.gov.hmrc.exports.services.mapping.MetaDataBuilder
+import uk.gov.hmrc.exports.services.mapping.CancellationMetaDataBuilder
 import uk.gov.hmrc.exports.services.{SubmissionService, WcoMapperService}
 import uk.gov.hmrc.http.HeaderCarrier
 import util.testdata.ExportsDeclarationBuilder
@@ -49,7 +49,7 @@ class SubmissionServiceSpec
   private val submissionRepository: SubmissionRepository = mock[SubmissionRepository]
   private val declarationRepository: DeclarationRepository = mock[DeclarationRepository]
   private val notificationRepository: NotificationRepository = mock[NotificationRepository]
-  private val metaDataBuilder: MetaDataBuilder = mock[MetaDataBuilder]
+  private val metaDataBuilder: CancellationMetaDataBuilder = mock[CancellationMetaDataBuilder]
   private val wcoMapperService: WcoMapperService = mock[WcoMapperService]
   private val submissionService = new SubmissionService(
     customsDeclarationsConnector = customsDeclarationsConnector,

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/DeclarationTypeCodeMappingSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/DeclarationTypeCodeMappingSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping
 
 import org.scalatest.{Matchers, WordSpec}
-import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AllowedAdditionalDeclarationTypes
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AdditionalDeclarationType
 import uk.gov.hmrc.exports.models.declaration.DispatchLocation.AllowedDispatchLocations
 import uk.gov.hmrc.exports.models.declaration.{AdditionalDeclarationType, DispatchLocation}
 import wco.datamodel.wco.declaration_ds.dms._2.DeclarationTypeCodeType
@@ -28,20 +28,20 @@ class DeclarationTypeCodeMappingSpec extends WordSpec with Matchers {
 
     "return CodeType with value EXZ for OutsideEU and Standard" in {
       val dispatchLocation = DispatchLocation(AllowedDispatchLocations.OutsideEU)
-      val additionalDeclarationTypeCode = AdditionalDeclarationType(AllowedAdditionalDeclarationTypes.Standard)
+      val additionalDeclarationTypeCode = AdditionalDeclarationType.SUPPLEMENTARY_EIDR
       val codeType = additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(Some(dispatchLocation), Some(additionalDeclarationTypeCode))
       codeType.getValue should be("EXZ")
     }
 
     "return CodeType with value COY for SpecialFiscalTerritory and Simplified" in {
       val dispatchLocation = DispatchLocation(AllowedDispatchLocations.SpecialFiscalTerritory)
-      val additionalDeclarationTypeCode = AdditionalDeclarationType(AllowedAdditionalDeclarationTypes.Simplified)
+      val additionalDeclarationTypeCode = AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED
       val codeType = additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(Some(dispatchLocation), Some(additionalDeclarationTypeCode))
       codeType.getValue should be("COY")
     }
 
     "return CodeType with value Y for None and Simplified" in {
-      val additionalDeclarationTypeCode = AdditionalDeclarationType(AllowedAdditionalDeclarationTypes.Simplified)
+      val additionalDeclarationTypeCode = AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED
       val codeType =
         additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(None, Some(additionalDeclarationTypeCode))
       codeType.getValue should be("Y")
@@ -60,7 +60,7 @@ class DeclarationTypeCodeMappingSpec extends WordSpec with Matchers {
   ): DeclarationTypeCodeType = {
     val declarationTypeCodeType = new DeclarationTypeCodeType
     val typeCode: String = dispatchLocation.map(_.dispatchLocation).getOrElse("") +
-      additionalDeclarationType.map(_.additionalDeclarationType).getOrElse("")
+      additionalDeclarationType.map(_.toString).getOrElse("")
     declarationTypeCodeType.setValue(typeCode)
     declarationTypeCodeType
   }

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilderSpec.scala
@@ -28,7 +28,7 @@ class ExitOfficeBuilderSpec extends WordSpec with Matchers with ExportsDeclarati
   "ExitOfficeBuilder" should {
 
     "build then add" when {
-      for(declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED)) {
+      for (declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED)) {
         s"$declarationType journey with no data" in {
           val model = aDeclaration(withType(declarationType), withoutOfficeOfExit())
           val declaration = new Declaration()

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilderSpec.scala
@@ -18,6 +18,7 @@ package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.DeclarationType
+import uk.gov.hmrc.exports.models.DeclarationType.DeclarationType
 import uk.gov.hmrc.exports.services.mapping.declaration.ExitOfficeBuilder
 import util.testdata.ExportsDeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
@@ -27,41 +28,24 @@ class ExitOfficeBuilderSpec extends WordSpec with Matchers with ExportsDeclarati
   "ExitOfficeBuilder" should {
 
     "build then add" when {
-      "standard journey with no data" in {
-        val model = aDeclaration(withType(DeclarationType.STANDARD), withoutOfficeOfExit())
-        val declaration = new Declaration()
+      for(declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED)) {
+        s"$declarationType journey with no data" in {
+          val model = aDeclaration(withType(declarationType), withoutOfficeOfExit())
+          val declaration = new Declaration()
 
-        builder.buildThenAdd(model, declaration)
+          builder.buildThenAdd(model, declaration)
 
-        declaration.getExitOffice should be(null)
-      }
+          declaration.getExitOffice should be(null)
+        }
 
-      "supplementary journey with no data" in {
-        val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withoutOfficeOfExit())
-        val declaration = new Declaration()
+        s"$declarationType journey with populated data" in {
+          val model = aDeclaration(withType(declarationType), withOfficeOfExit(officeId = "office-id"))
+          val declaration = new Declaration()
 
-        builder.buildThenAdd(model, declaration)
+          builder.buildThenAdd(model, declaration)
 
-        declaration.getExitOffice should be(null)
-      }
-
-      "standard journey with populated data" in {
-        val model = aDeclaration(withType(DeclarationType.STANDARD), withOfficeOfExit(officeId = "office-id"))
-        val declaration = new Declaration()
-
-        builder.buildThenAdd(model, declaration)
-
-        declaration.getExitOffice.getID.getValue should be("office-id")
-      }
-
-      "supplementary journey with populated data" in {
-        val model =
-          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withOfficeOfExit(officeId = "office-id"))
-        val declaration = new Declaration()
-
-        builder.buildThenAdd(model, declaration)
-
-        declaration.getExitOffice.getID.getValue should be("office-id")
+          declaration.getExitOffice.getID.getValue should be("office-id")
+        }
       }
     }
   }

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilderSpec.scala
@@ -39,7 +39,7 @@ class PresentationOfficeBuilderSpec extends WordSpec with Matchers with ExportsD
         declaration.getPresentationOffice should be(null)
       }
 
-      for(declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED)) {
+      for (declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED)) {
         s"Declaration Type $declarationType" when {
           "no office of exit" in {
             val model = aDeclaration(withType(declarationType), withoutOfficeOfExit())

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/PresentationOfficeBuilderSpec.scala
@@ -18,6 +18,7 @@ package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.DeclarationType
+import uk.gov.hmrc.exports.models.DeclarationType.DeclarationType
 import uk.gov.hmrc.exports.services.mapping.declaration.PresentationOfficeBuilder
 import util.testdata.ExportsDeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
@@ -27,26 +28,8 @@ class PresentationOfficeBuilderSpec extends WordSpec with Matchers with ExportsD
   "PresentationOfficeBuilder" should {
 
     "build then add" when {
-      "no office of exit" in {
-        val model = aDeclaration(withType(DeclarationType.STANDARD), withoutOfficeOfExit())
-        val declaration = new Declaration()
 
-        builder.buildThenAdd(model, declaration)
-
-        declaration.getPresentationOffice should be(null)
-      }
-
-      "empty presentation office id" in {
-        val model =
-          aDeclaration(withType(DeclarationType.STANDARD), withOfficeOfExit(presentationOfficeId = None))
-        val declaration = new Declaration()
-
-        builder.buildThenAdd(model, declaration)
-
-        declaration.getPresentationOffice should be(null)
-      }
-
-      "type is not standard" in {
+      "type is supplementary" in {
         val model =
           aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withOfficeOfExit(presentationOfficeId = Some("id")))
         val declaration = new Declaration()
@@ -56,14 +39,37 @@ class PresentationOfficeBuilderSpec extends WordSpec with Matchers with ExportsD
         declaration.getPresentationOffice should be(null)
       }
 
-      "populated" in {
-        val model =
-          aDeclaration(withType(DeclarationType.STANDARD), withOfficeOfExit(presentationOfficeId = Some("id")))
-        val declaration = new Declaration()
+      for(declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED)) {
+        s"Declaration Type $declarationType" when {
+          "no office of exit" in {
+            val model = aDeclaration(withType(declarationType), withoutOfficeOfExit())
+            val declaration = new Declaration()
 
-        builder.buildThenAdd(model, declaration)
+            builder.buildThenAdd(model, declaration)
 
-        declaration.getPresentationOffice.getID.getValue should be("id")
+            declaration.getPresentationOffice should be(null)
+          }
+
+          "empty presentation office id" in {
+            val model =
+              aDeclaration(withType(declarationType), withOfficeOfExit(presentationOfficeId = None))
+            val declaration = new Declaration()
+
+            builder.buildThenAdd(model, declaration)
+
+            declaration.getPresentationOffice should be(null)
+          }
+
+          "populated" in {
+            val model =
+              aDeclaration(withType(declarationType), withOfficeOfExit(presentationOfficeId = Some("id")))
+            val declaration = new Declaration()
+
+            builder.buildThenAdd(model, declaration)
+
+            declaration.getPresentationOffice.getID.getValue should be("id")
+          }
+        }
       }
     }
   }

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilderSpec.scala
@@ -18,6 +18,7 @@ package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.exports.models.DeclarationType
+import uk.gov.hmrc.exports.models.DeclarationType.DeclarationType
 import uk.gov.hmrc.exports.services.mapping.declaration.SpecificCircumstancesCodeBuilder
 import util.testdata.ExportsDeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
@@ -27,27 +28,7 @@ class SpecificCircumstancesCodeBuilderSpec extends WordSpec with Matchers with E
   "SpecificCircumstancesCodeBuilder" should {
 
     "build then add" when {
-
-      "no office of exit" in {
-        val model = aDeclaration(withType(DeclarationType.STANDARD), withoutOfficeOfExit())
-        val declaration = new Declaration()
-
-        builder.buildThenAdd(model, declaration)
-
-        declaration.getSpecificCircumstancesCodeCode should be(null)
-      }
-
-      "invalid circumstance type" in {
-        val model =
-          aDeclaration(withType(DeclarationType.STANDARD), withOfficeOfExit(circumstancesCode = Some("")))
-        val declaration = new Declaration()
-
-        builder.buildThenAdd(model, declaration)
-
-        declaration.getSpecificCircumstancesCodeCode should be(null)
-      }
-
-      "type is not standard" in {
+      "type is supplementary" in {
         val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withOfficeOfExit(circumstancesCode = Some("Yes")))
         val declaration = new Declaration()
 
@@ -56,14 +37,37 @@ class SpecificCircumstancesCodeBuilderSpec extends WordSpec with Matchers with E
         declaration.getSpecificCircumstancesCodeCode should be(null)
       }
 
-      "valid circumstance type" in {
-        val model =
-          aDeclaration(withType(DeclarationType.STANDARD), withOfficeOfExit(circumstancesCode = Some("Yes")))
-        val declaration = new Declaration()
+      for(declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED)) {
+        s"Declaration Type $declarationType" when {
+          "no office of exit" in {
+            val model = aDeclaration(withType(declarationType), withoutOfficeOfExit())
+            val declaration = new Declaration()
 
-        builder.buildThenAdd(model, declaration)
+            builder.buildThenAdd(model, declaration)
 
-        declaration.getSpecificCircumstancesCodeCode.getValue should be("A20")
+            declaration.getSpecificCircumstancesCodeCode should be(null)
+          }
+
+          "invalid circumstance type" in {
+            val model =
+              aDeclaration(withType(declarationType), withOfficeOfExit(circumstancesCode = Some("")))
+            val declaration = new Declaration()
+
+            builder.buildThenAdd(model, declaration)
+
+            declaration.getSpecificCircumstancesCodeCode should be(null)
+          }
+
+          "valid circumstance type" in {
+            val model =
+              aDeclaration(withType(declarationType), withOfficeOfExit(circumstancesCode = Some("Yes")))
+            val declaration = new Declaration()
+
+            builder.buildThenAdd(model, declaration)
+
+            declaration.getSpecificCircumstancesCodeCode.getValue should be("A20")
+          }
+        }
       }
     }
   }

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/SpecificCircumstancesCodeBuilderSpec.scala
@@ -37,7 +37,7 @@ class SpecificCircumstancesCodeBuilderSpec extends WordSpec with Matchers with E
         declaration.getSpecificCircumstancesCodeCode should be(null)
       }
 
-      for(declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED)) {
+      for (declarationType: DeclarationType <- Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED)) {
         s"Declaration Type $declarationType" when {
           "no office of exit" in {
             val model = aDeclaration(withType(declarationType), withoutOfficeOfExit())

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/TypeCodeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/TypeCodeBuilderSpec.scala
@@ -17,6 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType
 import uk.gov.hmrc.exports.services.mapping.declaration.TypeCodeBuilder
 import util.testdata.ExportsDeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
@@ -28,7 +29,7 @@ class TypeCodeBuilderSpec extends WordSpec with Matchers with ExportsDeclaration
 
     "Build then add from ExportsDeclaration" in {
       val declaration = new Declaration
-      val model = aDeclaration(withDispatchLocation("EX"), withAdditionalDeclarationType("Y"))
+      val model = aDeclaration(withDispatchLocation("EX"), withAdditionalDeclarationType(AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED))
       builder.buildThenAdd(model, declaration)
 
       declaration.getTypeCode.getValue should be("EXY")

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/consignment/DeclarationConsignmentBuilderSpec.scala
@@ -56,6 +56,21 @@ class DeclarationConsignmentBuilderSpec extends WordSpec with Matchers with Mock
         verify(consignmentCarrierBuilder).buildThenAdd(refEq(model), any[Declaration.Consignment])
       }
 
+      "simplified journey" in {
+        // Given
+        val model = aDeclaration(withType(DeclarationType.SIMPLIFIED))
+        val declaration = new Declaration()
+
+        // When
+        builder.buildThenAdd(model, declaration)
+
+        // Then
+        declaration.getConsignment should not be null
+        verify(freightBuilder).buildThenAdd(refEq(model), any[Declaration.Consignment])
+        verify(iteneraryBuilder).buildThenAdd(refEq(model), any[Declaration.Consignment])
+        verify(consignmentCarrierBuilder).buildThenAdd(refEq(model), any[Declaration.Consignment])
+      }
+
       "other journey" in {
         // Given
         val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
@@ -36,9 +36,9 @@ class ConsignmentBuilderSpec extends WordSpec with Matchers with ExportsDeclarat
 
   private val builder = new ConsignmentBuilder(goodsLocationBuilder, containerCodeBuilder, departureTransportMeansBuilder, transportEquipmentBuilder)
 
-  override protected def beforeEach(): Unit = {
-    super.beforeEach()
+  override protected def afterEach(): Unit = {
     reset(containerCodeBuilder, goodsLocationBuilder, departureTransportMeansBuilder, transportEquipmentBuilder)
+    super.afterEach()
   }
 
   "ConsignmentBuilder" should {

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
@@ -36,7 +36,6 @@ class ConsignmentBuilderSpec extends WordSpec with Matchers with ExportsDeclarat
 
   private val builder = new ConsignmentBuilder(goodsLocationBuilder, containerCodeBuilder, departureTransportMeansBuilder, transportEquipmentBuilder)
 
-
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     reset(containerCodeBuilder, goodsLocationBuilder, departureTransportMeansBuilder, transportEquipmentBuilder)

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -20,6 +20,7 @@ import java.time.{LocalDateTime, ZoneOffset}
 import java.util.UUID
 
 import uk.gov.hmrc.exports.models.DeclarationType.DeclarationType
+import uk.gov.hmrc.exports.models.declaration.AdditionalDeclarationType.AdditionalDeclarationType
 import uk.gov.hmrc.exports.models.declaration.DeclarationStatus.DeclarationStatus
 import uk.gov.hmrc.exports.models.declaration._
 import uk.gov.hmrc.exports.models.{DeclarationType, Eori}
@@ -70,8 +71,8 @@ trait ExportsDeclarationBuilder {
 
   def withoutAdditionalDeclarationType(): ExportsDeclarationModifier = _.copy(additionalDeclarationType = None)
 
-  def withAdditionalDeclarationType(decType: String = "dev-type"): ExportsDeclarationModifier =
-    _.copy(additionalDeclarationType = Some(AdditionalDeclarationType(decType)))
+  def withAdditionalDeclarationType(decType: AdditionalDeclarationType = AdditionalDeclarationType.STANDARD_FRONTIER): ExportsDeclarationModifier =
+    _.copy(additionalDeclarationType = Some(decType))
 
   def withoutDispatchLocation: ExportsDeclarationModifier = _.copy(dispatchLocation = None)
 


### PR DESCRIPTION
This permits Simplified Declarations following the same rules as Standard Declarations. These rules may change in subsequent stories.

As part of this change I have refactored AdditionalDeclarationType into an Enum, given there will be more of these to come I think now is a good opportunity to do it.