### PR TITLE
CEDS-1950 Make WarehouseIdentification backwards compatible

### DIFF
--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilder.scala
@@ -30,17 +30,20 @@ class WarehouseBuilder @Inject()() extends ModifyingBuilder[WarehouseIdentificat
     }
 
   private def isDefined(warehouse: WarehouseIdentification): Boolean =
-    warehouse.identificationNumber.isDefined && warehouse.identificationType.isDefined
+    warehouse.identificationNumber.isDefined
 
   private def createWarehouse(data: WarehouseIdentification): Warehouse = {
     val warehouse = new Warehouse()
 
+    val warehouseIdentificationType = data.identificationNumber.map(_.substring(0, 1)).getOrElse("")
+    val warehouseIdentificationNumber = data.identificationNumber.map(_.substring(1)).getOrElse("")
+
     val id = new WarehouseIdentificationIDType()
-    id.setValue(data.identificationNumber.getOrElse(""))
+    id.setValue(warehouseIdentificationNumber)
     warehouse.setID(id)
 
     val typeCode = new WarehouseTypeCodeType()
-    typeCode.setValue(data.identificationType.getOrElse(""))
+    typeCode.setValue(warehouseIdentificationType)
     warehouse.setTypeCode(typeCode)
 
     warehouse

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
@@ -31,7 +31,7 @@ class WarehouseBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
         val builder = new WarehouseBuilder
         val goodsShipment = new GoodsShipment
-        builder.buildThenAdd(WarehouseIdentification(Some("GBWKG001"), Some("R"), Some("1234567GB"), Some("2")), goodsShipment)
+        builder.buildThenAdd(WarehouseIdentification(Some("GBWKG001"), Some("R"), Some("R1234567GB"), Some("2")), goodsShipment)
         val warehouse = goodsShipment.getWarehouse
         warehouse.getID.getValue should be("1234567GB")
         warehouse.getTypeCode.getValue should be("R")
@@ -40,10 +40,11 @@ class WarehouseBuilderSpec extends WordSpec with Matchers with MockitoSugar {
       "identificationType is not supplied" in {
         val builder = new WarehouseBuilder
         val goodsShipment = new GoodsShipment
-        builder.buildThenAdd(WarehouseIdentification(Some("GBWKG001"), None, Some("1234567GB"), Some("2")), goodsShipment)
+        builder.buildThenAdd(WarehouseIdentification(Some("GBWKG001"), None, Some("R1234567GB"), Some("2")), goodsShipment)
 
         val warehouse = goodsShipment.getWarehouse
-        warehouse should be(null)
+        warehouse.getID.getValue should be("1234567GB")
+        warehouse.getTypeCode.getValue should be("R")
       }
 
       "identificationNumber is not supplied" in {


### PR DESCRIPTION
As part of the story we have removed the `WarehouseIdentificationType`
from the user journey, but it is still required to go into the DMS
payload.

James W. and Joe will create a story to update the `hint` on the
warehouse IdentificationNumber page and to provide new validation rules
for the Warehouse type.
That ticket will be played in the following sprint.

In the meantime this change is simply not to downgrade the payload that
is sent to DMS, as DMS expects both identificationNumber and Type or
none of them.

The current Warehouse model will also be replaced in a subsequent story this sprint.