### PR TITLE
CEDS-1972 - fix for bug mapping CUS code to 'Classification'

### DIFF
--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
@@ -64,28 +64,24 @@ class GovernmentAgencyGoodsItemBuilder @Inject()(
     wcoGovernmentAgencyGoodsItem: WCOGovernmentAgencyGoodsItem,
     declarationType: DeclarationType
   ): Unit = {
-    val combinedCommodity = for {
-      commodityWithoutGoodsMeasure <- mapExportItemToCommodity(exportItem)
-      commodityOnlyGoodsMeasure = mapCommodityMeasureToCommodity(exportItem.commodityMeasure, declarationType)
-    } yield combineCommodities(commodityWithoutGoodsMeasure, commodityOnlyGoodsMeasure)
+    val commodityWithoutGoodsMeasure = mapCommodityValuesToCommodity(exportItem)
+    val commodityOnlyGoodsMeasure = mapCommodityMeasureToCommodity(exportItem.commodityMeasure, declarationType)
 
-    combinedCommodity.foreach(commodityBuilder.buildThenAdd(_, wcoGovernmentAgencyGoodsItem))
+    val combinedCommodity = combineCommodities(commodityWithoutGoodsMeasure, commodityOnlyGoodsMeasure)
+
+    commodityBuilder.buildThenAdd(combinedCommodity, wcoGovernmentAgencyGoodsItem)
   }
-  private def mapExportItemToCommodity(exportItem: ExportItem): Option[Commodity] =
-    if (exportItem.commodityDetails.isDefined) {
-      Some(cachingMappingHelper.commodityFromExportItem(exportItem))
-    } else {
-      None
-    }
+  private def mapCommodityValuesToCommodity(exportItem: ExportItem): Commodity =
+    cachingMappingHelper.commodityFromExportItem(exportItem)
 
   private def mapCommodityMeasureToCommodity(commodityMeasure: Option[CommodityMeasure], declarationType: DeclarationType): Option[Commodity] =
     if (journeysWithCommodityMeasurements.contains(declarationType)) {
       commodityMeasure.map(measure => cachingMappingHelper.mapGoodsMeasure(measure))
     } else None
 
-  private def combineCommodities(commodityPart1: Commodity, commodityPart2: Option[Commodity]): Commodity =
-    commodityPart2
-      .map(commodityPart2Obj => commodityPart1.copy(goodsMeasure = commodityPart2Obj.goodsMeasure))
-      .getOrElse(commodityPart1)
+  private def combineCommodities(commodityWithoutGoodsMeasure: Commodity, commodityOnlyGoodsMeasure: Option[Commodity]): Commodity =
+    commodityOnlyGoodsMeasure
+      .map(commodityPart2Obj => commodityWithoutGoodsMeasure.copy(goodsMeasure = commodityPart2Obj.goodsMeasure))
+      .getOrElse(commodityWithoutGoodsMeasure)
 
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
@@ -63,19 +63,19 @@ class GovernmentAgencyGoodsItemBuilder @Inject()(
     exportItem: ExportItem,
     wcoGovernmentAgencyGoodsItem: WCOGovernmentAgencyGoodsItem,
     declarationType: DeclarationType
-  ) = {
+  ): Unit = {
     val combinedCommodity = for {
-      commodityWithoutGoodsMeasure <- mapItemTypeToCommodity(exportItem)
+      commodityWithoutGoodsMeasure <- mapExportItemToCommodity(exportItem)
       commodityOnlyGoodsMeasure = mapCommodityMeasureToCommodity(exportItem.commodityMeasure, declarationType)
     } yield combineCommodities(commodityWithoutGoodsMeasure, commodityOnlyGoodsMeasure)
 
     combinedCommodity.foreach(commodityBuilder.buildThenAdd(_, wcoGovernmentAgencyGoodsItem))
   }
-  private def mapItemTypeToCommodity(exportItem: ExportItem): Option[Commodity] =
-    (exportItem.itemType, exportItem.commodityDetails) match {
-      case (Some(item), Some(details)) =>
-        Some(cachingMappingHelper.commodityFromItemTypes(item, details, exportItem.dangerousGoodsCode, exportItem.cusCode, exportItem.taricCodes))
-      case _ => None
+  private def mapExportItemToCommodity(exportItem: ExportItem): Option[Commodity] =
+    if (exportItem.commodityDetails.isDefined) {
+      Some(cachingMappingHelper.commodityFromExportItem(exportItem))
+    } else {
+      None
     }
 
   private def mapCommodityMeasureToCommodity(commodityMeasure: Option[CommodityMeasure], declarationType: DeclarationType): Option[Commodity] =

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/CachingMappingHelperSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/CachingMappingHelperSpec.scala
@@ -44,17 +44,22 @@ class CachingMappingHelperSpec extends WordSpec with Matchers {
     }
 
     "mapCommodity" when {
-      val itemType: ItemType = ItemType(Seq("nationalAdditionalCodes"), "10")
-      val commodityDetails = CommodityDetails(Some("commodityCode"), "description")
-      val dangerousGoodsCode = Some(UNDangerousGoodsCode(Some("unDangerousGoodsCode")))
-      val cusCode = Some(CUSCode(Some("cusCode")))
-      val taricCodes = List(TaricCode("taricAdditionalCodes"))
 
       "all values provided" in {
-        val commodity = new CachingMappingHelper().commodityFromItemTypes(itemType, commodityDetails, dangerousGoodsCode, cusCode, taricCodes)
+        val exportItem = ExportItem(
+          "id",
+          itemType = Some(ItemType(Seq("nationalAdditionalCodes"), "10")),
+          commodityDetails = Some(CommodityDetails(Some("commodityCode"), "description")),
+          dangerousGoodsCode = Some(UNDangerousGoodsCode(Some("unDangerousGoodsCode"))),
+          cusCode = Some(CUSCode(Some("cusCode"))),
+          taricCodes = List(TaricCode("taricAdditionalCodes"))
+        )
 
-        commodity.description.get shouldBe "description"
-        commodity.dangerousGoods.head.undgid.get shouldBe "unDangerousGoodsCode"
+        val commodity = new CachingMappingHelper().commodityFromExportItem(exportItem)
+
+        commodity.description shouldBe Some("description")
+        commodity.dangerousGoods.size shouldBe 1
+        commodity.dangerousGoods.head.undgid shouldBe Some("unDangerousGoodsCode")
         commodity.classifications.map(c => c.id) shouldBe Seq(
           Some("commodityCode"),
           Some("cusCode"),
@@ -63,13 +68,28 @@ class CachingMappingHelperSpec extends WordSpec with Matchers {
         )
       }
 
-      "UN Dangerous Goods Code not provided" in {
-        val commodity = new CachingMappingHelper().commodityFromItemTypes(itemType, commodityDetails, None, None, List.empty)
+      "Only commodity code and description provided" in {
+        val exportItem = ExportItem("id", commodityDetails = Some(CommodityDetails(Some("commodityCode"), "description")))
 
-        commodity.description.get shouldBe "description"
-        commodity.classifications.head.id.get shouldBe "commodityCode"
+        val commodity = new CachingMappingHelper().commodityFromExportItem(exportItem)
+
+        commodity.description shouldBe Some("description")
         commodity.dangerousGoods shouldBe Seq.empty
+
+        commodity.classifications.map(c => c.id) shouldBe Seq(Some("commodityCode"))
       }
+
+      "Only description provided" in {
+        val exportItem = ExportItem("id", commodityDetails = Some(CommodityDetails(None, "description")))
+
+        val commodity = new CachingMappingHelper().commodityFromExportItem(exportItem)
+
+        commodity.description shouldBe Some("description")
+        commodity.dangerousGoods shouldBe Seq.empty
+
+        commodity.classifications shouldBe Seq.empty
+      }
+
     }
 
   }

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
@@ -73,16 +73,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
 
         when(mockCachingMappingHelper.mapGoodsMeasure(any[CommodityMeasure]))
           .thenReturn(Commodity(description = Some("Some Commodity")))
-        when(
-          mockCachingMappingHelper
-            .commodityFromItemTypes(
-              any[ItemType],
-              any[CommodityDetails],
-              any[Option[UNDangerousGoodsCode]],
-              any[Option[CUSCode]],
-              any[List[TaricCode]]
-            )
-        ).thenReturn(Commodity(description = Some("Some Commodity")))
+        when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Commodity(description = Some("Some Commodity")))
 
         val goodsShipment = new GoodsShipment
         builder.buildThenAdd(exportsDeclaration, goodsShipment)
@@ -95,13 +86,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
         verify(additionalDocumentsBuilder).buildThenAdd(refEq(exportItem), any[GoodsShipment.GovernmentAgencyGoodsItem])
         verify(commodityBuilder).buildThenAdd(any[Commodity], any[GoodsShipment.GovernmentAgencyGoodsItem])
         verify(mockCachingMappingHelper).mapGoodsMeasure(any[CommodityMeasure])
-        verify(mockCachingMappingHelper).commodityFromItemTypes(
-          any[ItemType],
-          any[CommodityDetails],
-          any[Option[UNDangerousGoodsCode]],
-          any[Option[CUSCode]],
-          any[List[TaricCode]]
-        )
+        verify(mockCachingMappingHelper).commodityFromExportItem(any[ExportItem])
         verify(dutyTaxPartyBuilder)
           .buildThenAdd(any[AdditionalFiscalReference], any[GoodsShipment.GovernmentAgencyGoodsItem])
         goodsShipment.getGovernmentAgencyGoodsItem shouldNot be(empty)
@@ -121,16 +106,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
 
         when(mockCachingMappingHelper.mapGoodsMeasure(any[CommodityMeasure]))
           .thenReturn(Commodity(description = Some("Some Commodity")))
-        when(
-          mockCachingMappingHelper
-            .commodityFromItemTypes(
-              any[ItemType],
-              any[CommodityDetails],
-              any[Option[UNDangerousGoodsCode]],
-              any[Option[CUSCode]],
-              any[List[TaricCode]]
-            )
-        ).thenReturn(Commodity(description = Some("Some Commodity")))
+        when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Commodity(description = Some("Some Commodity")))
 
         val goodsShipment = new GoodsShipment
         builder.buildThenAdd(exportsDeclaration, goodsShipment)
@@ -143,13 +119,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
         verify(additionalDocumentsBuilder).buildThenAdd(refEq(exportItem), any[GoodsShipment.GovernmentAgencyGoodsItem])
         verify(commodityBuilder).buildThenAdd(any[Commodity], any[GoodsShipment.GovernmentAgencyGoodsItem])
         verify(mockCachingMappingHelper, times(0)).mapGoodsMeasure(any[CommodityMeasure])
-        verify(mockCachingMappingHelper).commodityFromItemTypes(
-          any[ItemType],
-          any[CommodityDetails],
-          any[Option[UNDangerousGoodsCode]],
-          any[Option[CUSCode]],
-          any[List[TaricCode]]
-        )
+        verify(mockCachingMappingHelper).commodityFromExportItem(any[ExportItem])
         verify(dutyTaxPartyBuilder)
           .buildThenAdd(any[AdditionalFiscalReference], any[GoodsShipment.GovernmentAgencyGoodsItem])
         goodsShipment.getGovernmentAgencyGoodsItem shouldNot be(empty)


### PR DESCRIPTION
Bug resulted in the creation of a Classification with a None identifier
(which is not permitted).
Took the opportunity to refactor the CachingMappingHelper to reduce the
expanding list of arguments passed to the
'getClassificationsFromItemTypes' method.