### PR TITLE
CEDS-1955 Clean up the Warehouse Model

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/Locations.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Locations.scala
@@ -32,19 +32,24 @@ object GoodsLocation {
   implicit val format: OFormat[GoodsLocation] = Json.format[GoodsLocation]
 }
 
-case class WarehouseIdentification(
-  supervisingCustomsOffice: Option[String],
-  identificationType: Option[String],
-  identificationNumber: Option[String],
-  inlandModeOfTransportCode: Option[String]
-)
-object WarehouseIdentification {
-  implicit val format: OFormat[WarehouseIdentification] = Json.format[WarehouseIdentification]
-}
-
 case class OfficeOfExit(officeId: String, presentationOfficeId: Option[String], circumstancesCode: Option[String])
 object OfficeOfExit {
   implicit val format: OFormat[OfficeOfExit] = Json.format[OfficeOfExit]
+}
+
+case class WarehouseIdentification(identificationNumber: Option[String])
+object WarehouseIdentification {
+  implicit val format = Json.format[WarehouseIdentification]
+}
+
+case class SupervisingCustomsOffice(supervisingCustomsOffice: Option[String])
+object SupervisingCustomsOffice {
+  implicit val format = Json.format[SupervisingCustomsOffice]
+}
+
+case class InlandModeOfTransportCode(inlandModeOfTransportCode: Option[String])
+object InlandModeOfTransportCode {
+  implicit val format = Json.format[InlandModeOfTransportCode]
 }
 
 case class Locations(
@@ -53,8 +58,10 @@ case class Locations(
   hasRoutingCountries: Option[Boolean] = None,
   routingCountries: Seq[String] = Seq.empty,
   goodsLocation: Option[GoodsLocation] = None,
+  officeOfExit: Option[OfficeOfExit] = None,
+  supervisingCustomsOffice: Option[SupervisingCustomsOffice] = None,
   warehouseIdentification: Option[WarehouseIdentification] = None,
-  officeOfExit: Option[OfficeOfExit] = None
+  inlandModeOfTransportCode: Option[InlandModeOfTransportCode] = None
 )
 object Locations {
   implicit val format: OFormat[Locations] = Json.format[Locations]

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/SupervisingOfficeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/SupervisingOfficeBuilder.scala
@@ -26,16 +26,16 @@ import wco.datamodel.wco.declaration_ds.dms._2._
 class SupervisingOfficeBuilder @Inject()() extends ModifyingBuilder[ExportsDeclaration, Declaration] {
 
   override def buildThenAdd(model: ExportsDeclaration, declaration: Declaration): Unit =
-    model.locations.warehouseIdentification
+    model.locations.supervisingCustomsOffice
       .flatMap(_.supervisingCustomsOffice)
       .map(createSupervisingOffice)
       .foreach(declaration.setSupervisingOffice)
 
-  private def createSupervisingOffice(data: String): SupervisingOffice = {
+  private def createSupervisingOffice(office: String): SupervisingOffice = {
     val supervisingOffice = new SupervisingOffice()
 
     val iDType = new SupervisingOfficeIdentificationIDType()
-    iDType.setValue(data)
+    iDType.setValue(office)
     supervisingOffice.setID(iDType)
 
     supervisingOffice

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilder.scala
@@ -58,8 +58,7 @@ class GoodsShipmentBuilder @Inject()(
 
     exportsCacheModel.consignmentReferences.foreach(ucrBuilder.buildThenAdd(_, goodsShipment))
 
-    exportsCacheModel.locations.warehouseIdentification
-      .foreach(warehouseBuilder.buildThenAdd(_, goodsShipment))
+    exportsCacheModel.locations.warehouseIdentification.foreach(warehouseBuilder.buildThenAdd(_, goodsShipment))
 
     exportsCacheModel.consignmentReferences.foreach(previousDocumentsBuilder.buildThenAdd(_, goodsShipment))
 

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilder.scala
@@ -24,26 +24,23 @@ import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Warehouse
 import wco.datamodel.wco.declaration_ds.dms._2.{WarehouseIdentificationIDType, WarehouseTypeCodeType}
 
 class WarehouseBuilder @Inject()() extends ModifyingBuilder[WarehouseIdentification, GoodsShipment] {
-  override def buildThenAdd(model: WarehouseIdentification, goodsShipment: GoodsShipment): Unit =
-    if (isDefined(model)) {
-      goodsShipment.setWarehouse(createWarehouse(model))
+  override def buildThenAdd(warehouseIdentification: WarehouseIdentification, goodsShipment: GoodsShipment): Unit =
+    if (warehouseIdentification.identificationNumber.nonEmpty) {
+      goodsShipment.setWarehouse(createWarehouse(warehouseIdentification))
     }
 
-  private def isDefined(warehouse: WarehouseIdentification): Boolean =
-    warehouse.identificationNumber.isDefined
-
-  private def createWarehouse(data: WarehouseIdentification): Warehouse = {
+  private def createWarehouse(warehouseIdentification: WarehouseIdentification): Warehouse = {
     val warehouse = new Warehouse()
 
-    val warehouseIdentificationType = data.identificationNumber.map(_.substring(0, 1)).getOrElse("")
-    val warehouseIdentificationNumber = data.identificationNumber.map(_.substring(1)).getOrElse("")
+    val identificationType = warehouseIdentification.identificationNumber.map(typeNumber => typeNumber.headOption.getOrElse(""))
+    val identificationNumber = warehouseIdentification.identificationNumber.map(number => number.tail).getOrElse("")
 
     val id = new WarehouseIdentificationIDType()
-    id.setValue(warehouseIdentificationNumber)
+    id.setValue(identificationNumber)
     warehouse.setID(id)
 
     val typeCode = new WarehouseTypeCodeType()
-    typeCode.setValue(warehouseIdentificationType)
+    typeCode.setValue(identificationType.getOrElse("").toString)
     warehouse.setTypeCode(typeCode)
 
     warehouse

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
@@ -39,7 +39,8 @@ class ConsignmentBuilder @Inject()(
     val warehouseIdentificationOpt = exportsCacheModel.locations.warehouseIdentification
 
     exportsCacheModel.departureTransport.foreach(
-      departureTransport => departureTransportMeansBuilder.buildThenAdd(departureTransport, warehouseIdentificationOpt, consignment)
+      departureTransport =>
+        departureTransportMeansBuilder.buildThenAdd(departureTransport, exportsCacheModel.locations.inlandModeOfTransportCode, consignment)
     )
 
     exportsCacheModel.`type` match {

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilder.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment
 
 import javax.inject.Inject
-import uk.gov.hmrc.exports.models.declaration.{DepartureTransport, WarehouseIdentification}
+import uk.gov.hmrc.exports.models.declaration.{DepartureTransport, InlandModeOfTransportCode}
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Consignment
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Consignment.DepartureTransportMeans
 import wco.datamodel.wco.declaration_ds.dms._2.{
@@ -27,24 +27,25 @@ import wco.datamodel.wco.declaration_ds.dms._2.{
 }
 
 class DepartureTransportMeansBuilder @Inject()() {
-  def buildThenAdd(departureTransport: DepartureTransport, warehouseIdentification: Option[WarehouseIdentification], consignment: Consignment): Unit =
-    if (isBorderTransportDefined(departureTransport) || isWarehouseIdentificationDefined(warehouseIdentification)) {
-      consignment.setDepartureTransportMeans(createDepartureTransportMeans(departureTransport, warehouseIdentification))
+  def buildThenAdd(
+    departureTransport: DepartureTransport,
+    inlandModeOfTransportCode: Option[InlandModeOfTransportCode],
+    consignment: Consignment
+  ): Unit =
+    if (isBorderTransportDefined(departureTransport) || inlandModeOfTransportCode.nonEmpty) {
+      consignment.setDepartureTransportMeans(createDepartureTransportMeans(departureTransport, inlandModeOfTransportCode))
     }
 
   private def isBorderTransportDefined(departureTransport: DepartureTransport): Boolean =
     departureTransport.meansOfTransportOnDepartureIDNumber.nonEmpty || departureTransport.meansOfTransportOnDepartureType.nonEmpty
 
-  private def isWarehouseIdentificationDefined(warehouseIdentification: Option[WarehouseIdentification]): Boolean =
-    warehouseIdentification.flatMap(_.inlandModeOfTransportCode).nonEmpty
-
   private def createDepartureTransportMeans(
     departureTransport: DepartureTransport,
-    warehouseIdentification: Option[WarehouseIdentification]
+    inlandModeOfTransportCode: Option[InlandModeOfTransportCode]
   ): Consignment.DepartureTransportMeans = {
     val departureTransportMeans = new DepartureTransportMeans()
 
-    warehouseIdentification.flatMap(_.inlandModeOfTransportCode).foreach { value =>
+    inlandModeOfTransportCode.flatMap(_.inlandModeOfTransportCode).foreach { value =>
       val modeCodeType = new DepartureTransportMeansModeCodeType()
       modeCodeType.setValue(value)
       departureTransportMeans.setModeCode(modeCodeType)

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/SupervisingOfficeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/SupervisingOfficeBuilderSpec.scala
@@ -26,17 +26,8 @@ class SupervisingOfficeBuilderSpec extends WordSpec with Matchers with ExportsDe
   "SupervisingOfficeBuilder" should {
 
     "build then add" when {
-      "no warehouse identification" in {
-        val model = aDeclaration(withoutWarehouseIdentification())
-        val declaration = new Declaration()
-
-        new SupervisingOfficeBuilder().buildThenAdd(model, declaration)
-
-        declaration.getSupervisingOffice should be(null)
-      }
-
       "missing supervising customs office" in {
-        val model = aDeclaration(withWarehouseIdentification(supervisingCustomsOffice = None))
+        val model = aDeclaration()
         val declaration = new Declaration()
 
         new SupervisingOfficeBuilder().buildThenAdd(model, declaration)
@@ -45,7 +36,7 @@ class SupervisingOfficeBuilderSpec extends WordSpec with Matchers with ExportsDe
       }
 
       "populated" in {
-        val model = aDeclaration(withWarehouseIdentification(supervisingCustomsOffice = Some("value")))
+        val model = aDeclaration(withSupervisingCustomsOffice("value"))
         val declaration = new Declaration()
 
         new SupervisingOfficeBuilder().buildThenAdd(model, declaration)

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
@@ -128,7 +128,7 @@ class GoodsShipmentBuilderSpec extends WordSpec with Matchers with ExportsDeclar
       .buildThenAdd(refEq(correctConsignmentReferences), any[Declaration.GoodsShipment])
 
     verify(mockWarehouseBuilder)
-      .buildThenAdd(refEq(WarehouseIdentification(Some("GBWKG001"), Some("R"), None, Some("2"))), any[Declaration.GoodsShipment])
+      .buildThenAdd(refEq(WarehouseIdentification(Some("RGBWKG001"))), any[Declaration.GoodsShipment])
 
     verify(mockPreviousDocumentBuilder)
       .buildThenAdd(refEq(PreviousDocuments(Seq(correctPreviousDocument))), any[Declaration.GoodsShipment])
@@ -146,7 +146,8 @@ class GoodsShipmentBuilderSpec extends WordSpec with Matchers with ExportsDeclar
       withOriginationCountry(),
       withDestinationCountry(),
       withoutRoutingCountries(),
-      withWarehouseIdentification(WarehouseIdentification(Some("GBWKG001"), Some("R"), None, Some("2"))),
+      withWarehouseIdentification("RGBWKG001"),
+      withInlandModeOfTransport("2"),
       withConsignmentReferences("8GB123456789012-1234567890QWERTYUIO", "123LRN", Some("8GB123456789012")),
       withPreviousDocuments(correctPreviousDocument),
       withItem()

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
@@ -16,8 +16,8 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment
 
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.exports.models.declaration.WarehouseIdentification
 import uk.gov.hmrc.exports.services.mapping.goodsshipment.WarehouseBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
@@ -31,7 +31,7 @@ class WarehouseBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
         val builder = new WarehouseBuilder
         val goodsShipment = new GoodsShipment
-        builder.buildThenAdd(WarehouseIdentification(Some("GBWKG001"), Some("R"), Some("R1234567GB"), Some("2")), goodsShipment)
+        builder.buildThenAdd(WarehouseIdentification(Some("R1234567GB")), goodsShipment)
         val warehouse = goodsShipment.getWarehouse
         warehouse.getID.getValue should be("1234567GB")
         warehouse.getTypeCode.getValue should be("R")
@@ -40,7 +40,7 @@ class WarehouseBuilderSpec extends WordSpec with Matchers with MockitoSugar {
       "identificationType is not supplied" in {
         val builder = new WarehouseBuilder
         val goodsShipment = new GoodsShipment
-        builder.buildThenAdd(WarehouseIdentification(Some("GBWKG001"), None, Some("R1234567GB"), Some("2")), goodsShipment)
+        builder.buildThenAdd(WarehouseIdentification(Some("R1234567GB")), goodsShipment)
 
         val warehouse = goodsShipment.getWarehouse
         warehouse.getID.getValue should be("1234567GB")
@@ -50,7 +50,7 @@ class WarehouseBuilderSpec extends WordSpec with Matchers with MockitoSugar {
       "identificationNumber is not supplied" in {
         val builder = new WarehouseBuilder
         val goodsShipment = new GoodsShipment
-        builder.buildThenAdd(WarehouseIdentification(Some("GBWKG001"), Some("R"), None, Some("2")), goodsShipment)
+        builder.buildThenAdd(WarehouseIdentification(None), goodsShipment)
 
         val warehouse = goodsShipment.getWarehouse
         warehouse should be(null)

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
@@ -82,7 +82,7 @@ class ConsignmentBuilderSpec extends WordSpec with Matchers with ExportsDeclarat
         verify(departureTransportMeansBuilder)
           .buildThenAdd(
             refEq(DepartureTransport(borderModeOfTransportCode, meansOfTransportOnDepartureType, Some(meansOfTransportOnDepartureIDNumber))),
-            any[Option[WarehouseIdentification]],
+            any[Option[InlandModeOfTransportCode]],
             any[GoodsShipment.Consignment]
           )
 
@@ -127,7 +127,7 @@ class ConsignmentBuilderSpec extends WordSpec with Matchers with ExportsDeclarat
         verify(departureTransportMeansBuilder)
           .buildThenAdd(
             refEq(DepartureTransport(borderModeOfTransportCode, meansOfTransportOnDepartureType, Some(meansOfTransportOnDepartureIDNumber))),
-            any[Option[WarehouseIdentification]],
+            any[Option[InlandModeOfTransportCode]],
             any[GoodsShipment.Consignment]
           )
 
@@ -172,7 +172,7 @@ class ConsignmentBuilderSpec extends WordSpec with Matchers with ExportsDeclarat
         verify(departureTransportMeansBuilder)
           .buildThenAdd(
             refEq(DepartureTransport(borderModeOfTransportCode, meansOfTransportOnDepartureType, Some(meansOfTransportOnDepartureIDNumber))),
-            any[Option[WarehouseIdentification]],
+            any[Option[InlandModeOfTransportCode]],
             any[GoodsShipment.Consignment]
           )
 

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilderSpec.scala
@@ -17,7 +17,7 @@
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment
 
 import org.scalatest.{Matchers, WordSpec}
-import uk.gov.hmrc.exports.models.declaration.{DepartureTransport, WarehouseIdentification}
+import uk.gov.hmrc.exports.models.declaration.{DepartureTransport, InlandModeOfTransportCode}
 import uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment.DepartureTransportMeansBuilder
 import util.testdata.ExportsDeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
@@ -30,15 +30,13 @@ class DepartureTransportMeansBuilderSpec extends WordSpec with Matchers with Exp
       val meansOfTransportOnDepartureType = "T"
       val meansOfTransportOnDepartureIDNumber = "12345"
       val inlandModeOfTransport = "1"
-      val warehouseIdentificationOpt: Option[WarehouseIdentification] =
-        Some(WarehouseIdentification(None, None, None, Some(inlandModeOfTransport)))
 
       val builder = new DepartureTransportMeansBuilder
 
       val consignment = new GoodsShipment.Consignment
       builder.buildThenAdd(
         DepartureTransport(borderModeOfTransportCode, meansOfTransportOnDepartureType, Some(meansOfTransportOnDepartureIDNumber)),
-        warehouseIdentificationOpt,
+        Some(InlandModeOfTransportCode(Some(inlandModeOfTransport))),
         consignment
       )
 

--- a/test/util/SeedMongo.scala
+++ b/test/util/SeedMongo.scala
@@ -60,7 +60,9 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
         city = None
       )
     ),
-    withWarehouseIdentification(supervisingCustomsOffice = Some("GBLBA001"), inlandModeOfTransportCode = Some("1")),
+    withWarehouseIdentification("RGBLBA001"),
+    withSupervisingCustomsOffice("Belfast"),
+    withInlandModeOfTransport("1"),
     withOfficeOfExit("GB000054", Some("GBLBA003"), Some("No")),
     withItems(
       anItem(

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -32,6 +32,10 @@ trait ExportsDeclarationBuilder {
   protected val VALID_PERSONAL_UCR = "5GB123456789000"
   protected val VALID_DUCR = "5GB123456789000-123ABC456DEFIIIII"
   protected val VALID_LRN = "FG7676767889"
+
+  def aDeclaration(modifiers: ExportsDeclarationModifier*): ExportsDeclaration =
+    modifiers.foldLeft(modelWithDefaults)((current, modifier) => modifier(current))
+
   private def modelWithDefaults: ExportsDeclaration = ExportsDeclaration(
     id = uuid,
     eori = "eori",
@@ -54,12 +58,11 @@ trait ExportsDeclarationBuilder {
     natureOfTransaction = None
   )
 
-  def aDeclaration(modifiers: ExportsDeclarationModifier*): ExportsDeclaration =
-    modifiers.foldLeft(modelWithDefaults)((current, modifier) => modifier(current))
-
-  def withId(id: String): ExportsDeclarationModifier = _.copy(id = id)
+  private def uuid: String = UUID.randomUUID().toString
 
   // ************************************************* Builders ********************************************************
+
+  def withId(id: String): ExportsDeclarationModifier = _.copy(id = id)
 
   def withEori(eori: String): ExportsDeclarationModifier = _.copy(eori = eori)
 
@@ -171,25 +174,17 @@ trait ExportsDeclarationBuilder {
     m.copy(locations = m.locations.copy(goodsLocation = Some(goodsLocation)))
   }
 
-  def withoutWarehouseIdentification(): ExportsDeclarationModifier =
-    cache => cache.copy(locations = cache.locations.copy(warehouseIdentification = None))
+  def withWarehouseIdentification(warehouseIdentification: String): ExportsDeclarationModifier = { m =>
+    m.copy(locations = m.locations.copy(warehouseIdentification = Some(WarehouseIdentification(Some(warehouseIdentification)))))
+  }
 
-  def withWarehouseIdentification(warehouseIdentification: WarehouseIdentification): ExportsDeclarationModifier =
-    cache => cache.copy(locations = cache.locations.copy(warehouseIdentification = Some(warehouseIdentification)))
+  def withInlandModeOfTransport(inlandModeOfTransportCode: String): ExportsDeclarationModifier = { m =>
+    m.copy(locations = m.locations.copy(inlandModeOfTransportCode = Some(InlandModeOfTransportCode(Some(inlandModeOfTransportCode)))))
+  }
 
-  def withWarehouseIdentification(
-    supervisingCustomsOffice: Option[String] = None,
-    identificationType: Option[String] = None,
-    identificationNumber: Option[String] = None,
-    inlandModeOfTransportCode: Option[String] = None
-  ): ExportsDeclarationModifier =
-    cache =>
-      cache.copy(
-        locations = cache.locations.copy(
-          warehouseIdentification =
-            Some(WarehouseIdentification(supervisingCustomsOffice, identificationType, identificationNumber, inlandModeOfTransportCode))
-        )
-    )
+  def withSupervisingCustomsOffice(supervisingCustomsOffice: String): ExportsDeclarationModifier = { m =>
+    m.copy(locations = m.locations.copy(supervisingCustomsOffice = Some(SupervisingCustomsOffice(Some(supervisingCustomsOffice)))))
+  }
 
   def withoutOfficeOfExit(): ExportsDeclarationModifier =
     cache => cache.copy(locations = cache.locations.copy(officeOfExit = None))
@@ -211,8 +206,6 @@ trait ExportsDeclarationBuilder {
 
   def withItems(count: Int): ExportsDeclarationModifier =
     cache => cache.copy(items = cache.items ++ (1 to count).map(_ => ExportItem(id = uuid)).toSet)
-
-  private def uuid: String = UUID.randomUUID().toString
 
   def withoutTotalNumberOfItems(): ExportsDeclarationModifier = _.copy(totalNumberOfItems = None)
 


### PR DESCRIPTION
The work carried out by the splitting of the Warehouse page has been
done by reutilising the `WarehouseIdentification` model. This has proven
to be confusing and the `supervisingCustomsOffice` and
`inlandModeOfTransport` no longer belong to the WarehouseIdentification
model.

This change will require a change to the model in the FE application and
in the UAT/smoke/acceptance tests.

Also relates to: CEDS-1950, CEDS-1953, CEDS-1954