### PR TITLE
Update dependencies

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,8 +9,8 @@ object AppDependencies {
   val compile = Seq(
     "uk.gov.hmrc" %% "simple-reactivemongo" % "7.22.0-play-26",
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "0.45.0",
-    "uk.gov.hmrc" %% "wco-dec" % "0.31.0",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0",
+    "uk.gov.hmrc" %% "wco-dec" % "0.33.0",
     "uk.gov.hmrc" %% "logback-json-logger" % "4.6.0",
     "com.typesafe.play" %% "play-json-joda" % "2.6.10"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/"
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.3.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.4.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 
@@ -12,7 +12,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.20")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 


### PR DESCRIPTION
We're not able to use the newest version of sbt-plugin. Version 2.6.24 use akka version 2.5.25.
The last akka version that is compatible with reactive mongo is 2.5.23.
This is the reason that we need to use sbt-plugin 2.6.23.