### PR TITLE
CEDS-2083 - dont show questions not answered on summary

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
@@ -155,9 +155,9 @@ case class ExportItem(
   commodityDetails: Option[CommodityDetails] = None,
   dangerousGoodsCode: Option[UNDangerousGoodsCode] = None,
   cusCode: Option[CUSCode] = None,
-  taricCodes: List[TaricCode] = Nil,
-  nactCodes: List[NactCode] = Nil,
-  packageInformation: List[PackageInformation] = Nil,
+  taricCodes: Option[List[TaricCode]] = None,
+  nactCodes: Option[List[NactCode]] = None,
+  packageInformation: Option[List[PackageInformation]] = None,
   commodityMeasure: Option[CommodityMeasure] = None,
   additionalInformation: Option[AdditionalInformations] = None,
   documentsProducedData: Option[DocumentsProduced] = None

--- a/app/uk/gov/hmrc/exports/models/declaration/Transport.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Transport.scala
@@ -20,7 +20,7 @@ import play.api.libs.json.{Json, OFormat}
 
 case class Transport(
   transportPayment: Option[TransportPayment] = None,
-  containers: Seq[Container] = Seq.empty,
+  containers: Option[Seq[Container]] = None,
   borderModeOfTransportCode: Option[String] = None,
   meansOfTransportOnDepartureType: Option[String] = None,
   meansOfTransportOnDepartureIDNumber: Option[String] = None,

--- a/app/uk/gov/hmrc/exports/services/mapping/CachingMappingHelper.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/CachingMappingHelper.scala
@@ -28,8 +28,8 @@ class CachingMappingHelper {
       classifications = getClassifications(
         exportItem.commodityDetails.flatMap(_.combinedNomenclatureCode),
         exportItem.cusCode.flatMap(_.cusCode),
-        exportItem.nactCodes.map(_.nactCode),
-        exportItem.taricCodes.map(_.taricCode)
+        exportItem.nactCodes.map(_.map(_.nactCode)).getOrElse(List.empty),
+        exportItem.taricCodes.map(_.map(_.taricCode)).getOrElse(List.empty)
       ),
       dangerousGoods = exportItem.dangerousGoodsCode.flatMap(_.dangerousGoodsCode).map(code => Seq(DangerousGoods(Some(code)))).getOrElse(Seq.empty)
     )

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/ConsignmentBuilder.scala
@@ -34,14 +34,14 @@ class ConsignmentBuilder @Inject()(
     exportsCacheModel.locations.goodsLocation
       .foreach(goodsLocation => goodsLocationBuilder.buildThenAdd(goodsLocation, consignment))
 
-    containerCodeBuilder.buildThenAdd(exportsCacheModel.transport.containers, consignment)
+    containerCodeBuilder.buildThenAdd(exportsCacheModel.transport.containers.getOrElse(Seq.empty), consignment)
 
     departureTransportMeansBuilder.buildThenAdd(exportsCacheModel.transport, exportsCacheModel.locations.inlandModeOfTransportCode, consignment)
 
     exportsCacheModel.`type` match {
       case DeclarationType.STANDARD | DeclarationType.SIMPLIFIED | DeclarationType.SUPPLEMENTARY | DeclarationType.OCCASIONAL |
           DeclarationType.CLEARANCE =>
-        transportEquipmentBuilder.buildThenAdd(exportsCacheModel.transport.containers, consignment)
+        transportEquipmentBuilder.buildThenAdd(exportsCacheModel.transport.containers.getOrElse(Seq.empty), consignment)
       case _ => (): Unit
     }
 

--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/PackagingBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/PackagingBuilder.scala
@@ -26,11 +26,10 @@ import wco.datamodel.wco.declaration_ds.dms._2.{PackagingMarksNumbersIDType, Pac
 class PackagingBuilder @Inject()() extends ModifyingBuilder[ExportItem, GoodsShipment.GovernmentAgencyGoodsItem] {
 
   def buildThenAdd(exportItem: ExportItem, wcoGovernmentAgencyGoodsItem: GoodsShipment.GovernmentAgencyGoodsItem): Unit =
-    exportItem.packageInformation.zipWithIndex.foreach {
+    exportItem.packageInformation.getOrElse(List.empty).zipWithIndex.foreach {
       case (packing, index) =>
-        wcoGovernmentAgencyGoodsItem.getPackaging.add(
-          createWcoPackaging(index, packing.typesOfPackages, packing.numberOfPackages, packing.shippingMarks)
-        )
+        wcoGovernmentAgencyGoodsItem.getPackaging
+          .add(createWcoPackaging(index, packing.typesOfPackages, packing.numberOfPackages, packing.shippingMarks))
     }
 
   private def createWcoPackaging(sequenceNumeric: Int, typeCode: String, quantity: Int, markNumber: String): Packaging = {

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/CachingMappingHelperSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/CachingMappingHelperSpec.scala
@@ -52,8 +52,8 @@ class CachingMappingHelperSpec extends WordSpec with Matchers {
           commodityDetails = Some(CommodityDetails(Some("commodityCode"), "description")),
           dangerousGoodsCode = Some(UNDangerousGoodsCode(Some("unDangerousGoodsCode"))),
           cusCode = Some(CUSCode(Some("cusCode"))),
-          taricCodes = List(TaricCode("taricAdditionalCodes")),
-          nactCodes = List(NactCode("nationalAdditionalCodes"))
+          taricCodes = Some(List(TaricCode("taricAdditionalCodes"))),
+          nactCodes = Some(List(NactCode("nationalAdditionalCodes")))
         )
 
         val commodity = new CachingMappingHelper().commodityFromExportItem(exportItem)

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/ExportsItemBuilder.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/ExportsItemBuilder.scala
@@ -63,16 +63,20 @@ trait ExportsItemBuilder {
 
   def withCommodityDetails(data: CommodityDetails): ItemModifier = _.copy(commodityDetails = Some(data))
 
-  def withoutPackageInformation(): ItemModifier = _.copy(packageInformation = List.empty)
+  def withoutPackageInformation(): ItemModifier = _.copy(packageInformation = None)
 
   def withPackageInformation(first: PackageInformation, others: PackageInformation*): ItemModifier =
     withPackageInformation(List(first) ++ others.toList)
 
   def withPackageInformation(informations: List[PackageInformation]): ItemModifier =
-    _.copy(packageInformation = informations)
+    _.copy(packageInformation = Some(informations))
 
   def withPackageInformation(typesOfPackages: String = "", numberOfPackages: Int = 0, shippingMarks: String = ""): ItemModifier =
-    cache => cache.copy(packageInformation = cache.packageInformation :+ PackageInformation(typesOfPackages, numberOfPackages, shippingMarks))
+    cache =>
+      cache.copy(
+        packageInformation =
+          Some(cache.packageInformation.getOrElse(List.empty) :+ PackageInformation(typesOfPackages, numberOfPackages, shippingMarks))
+    )
 
   def withDocumentsProduced(first: DocumentProduced, docs: DocumentProduced*): ItemModifier = cache => {
     val existing = cache.documentsProducedData.map(_.documents).getOrElse(Seq.empty)

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -111,10 +111,10 @@ trait ExportsDeclarationBuilder {
     )
 
   def withoutContainerData(): ExportsDeclarationModifier =
-    declaration => declaration.copy(transport = declaration.transport.copy(containers = Seq.empty))
+    declaration => declaration.copy(transport = declaration.transport.copy(containers = None))
 
   def withContainerData(data: Container*): ExportsDeclarationModifier =
-    declaration => declaration.copy(transport = declaration.transport.copy(containers = data))
+    declaration => declaration.copy(transport = declaration.transport.copy(containers = Some(data)))
 
   def withPreviousDocuments(previousDocuments: PreviousDocument*): ExportsDeclarationModifier =
     _.copy(previousDocuments = Some(PreviousDocuments(previousDocuments)))


### PR DESCRIPTION
Changes to exports declaration model to support front-end changes to summary page to only show answers to questions asked.  This means continuing the practice of making a 'page' of answers an Option[T] - in this case replacing Lists/Sequences with Option[List/Seq]