### PR TITLE
CEDS-1439 - maintain item ordering

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequest.scala
+++ b/app/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequest.scala
@@ -34,7 +34,7 @@ case class ExportsDeclarationRequest(
   transport: Transport = Transport(),
   parties: Parties = Parties(),
   locations: Locations = Locations(),
-  items: Set[ExportItem] = Set.empty[ExportItem],
+  items: Seq[ExportItem] = Seq.empty,
   totalNumberOfItems: Option[TotalNumberOfItems] = None,
   previousDocuments: Option[PreviousDocuments] = None,
   natureOfTransaction: Option[NatureOfTransaction] = None

--- a/app/uk/gov/hmrc/exports/models/declaration/ExportsDeclaration.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportsDeclaration.scala
@@ -37,7 +37,7 @@ case class ExportsDeclaration(
   transport: Transport,
   parties: Parties,
   locations: Locations,
-  items: Set[ExportItem],
+  items: Seq[ExportItem],
   totalNumberOfItems: Option[TotalNumberOfItems],
   previousDocuments: Option[PreviousDocuments],
   natureOfTransaction: Option[NatureOfTransaction]

--- a/test/unit/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/request/ExportsDeclarationRequestSpec.scala
@@ -60,7 +60,7 @@ class ExportsDeclarationRequestSpec extends WordSpec with MustMatchers with Expo
     transport = transport,
     parties = parties,
     locations = locations,
-    items = Set(item),
+    items = Seq(item),
     totalNumberOfItems = Some(totalNumberOfItems),
     previousDocuments = Some(previousDocuments),
     natureOfTransaction = Some(natureOfTransaction)
@@ -80,7 +80,7 @@ class ExportsDeclarationRequestSpec extends WordSpec with MustMatchers with Expo
     transport = transport,
     parties = parties,
     locations = locations,
-    items = Set(item),
+    items = Seq(item),
     totalNumberOfItems = Some(totalNumberOfItems),
     previousDocuments = Some(previousDocuments),
     natureOfTransaction = Some(natureOfTransaction)

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -50,7 +50,7 @@ trait ExportsDeclarationBuilder {
     transport = Transport(),
     parties = Parties(),
     locations = Locations(),
-    items = Set.empty[ExportItem],
+    items = Seq.empty,
     totalNumberOfItems = None,
     previousDocuments = None,
     natureOfTransaction = None
@@ -205,13 +205,13 @@ trait ExportsDeclarationBuilder {
   ): ExportsDeclarationModifier =
     cache => cache.copy(locations = cache.locations.copy(officeOfExit = Some(OfficeOfExit(officeId, presentationOfficeId, circumstancesCode))))
 
-  def withoutItems(): ExportsDeclarationModifier = _.copy(items = Set.empty)
+  def withoutItems(): ExportsDeclarationModifier = _.copy(items = Seq.empty)
 
   def withItem(item: ExportItem = ExportItem(uuid)): ExportsDeclarationModifier =
-    m => m.copy(items = m.items + item)
+    m => m.copy(items = m.items :+ item)
 
   def withItems(item1: ExportItem, others: ExportItem*): ExportsDeclarationModifier =
-    _.copy(items = Set(item1) ++ others)
+    _.copy(items = Seq(item1) ++ others)
 
   def withItems(count: Int): ExportsDeclarationModifier =
     cache => cache.copy(items = cache.items ++ (1 to count).map(_ => ExportItem(id = uuid)).toSet)


### PR DESCRIPTION
Changing the collection type from Set to Seq ensures that insertion order is maintained.