### PR TITLE
CEDS-2111 Add Mongobee as MongoDB db migration tool

### DIFF
--- a/app/uk/gov/hmrc/exports/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/exports/config/AppConfig.scala
@@ -20,12 +20,15 @@ import java.time.{Clock, LocalTime}
 
 import com.google.inject.{Inject, Singleton}
 import play.api.{Configuration, Environment}
+import uk.gov.hmrc.exports.mongobee.MongobeeConfig
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.duration.FiniteDuration
 
 @Singleton
 class AppConfig @Inject()(val runModeConfiguration: Configuration, val environment: Environment, servicesConfig: ServicesConfig) {
+
+  MongobeeConfig(loadConfig("mongodb.uri"))
 
   lazy val clock: Clock = Clock.systemUTC()
 

--- a/app/uk/gov/hmrc/exports/mongobee/MongobeeConfig.scala
+++ b/app/uk/gov/hmrc/exports/mongobee/MongobeeConfig.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.mongobee
+
+import com.github.mongobee.Mongobee
+import com.google.inject.Singleton
+
+@Singleton
+case class MongobeeConfig(mongoURI: String) {
+  val runner = new Mongobee(mongoURI)
+
+  runner.setDbName("customs-declare-exports")
+  runner.setChangeLogsScanPackage("uk.gov.hmrc.exports.mongobee.changesets")
+
+  runner.execute()
+}

--- a/app/uk/gov/hmrc/exports/mongobee/changesets/DeclarationsChangelog.java
+++ b/app/uk/gov/hmrc/exports/mongobee/changesets/DeclarationsChangelog.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.mongobee.changesets;
+
+import com.github.mongobee.changeset.ChangeLog;
+import com.github.mongobee.changeset.ChangeSet;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DB;
+import com.mongodb.DBCursor;
+import com.mongodb.DBObject;
+import org.bson.Document;
+
+@ChangeLog
+public class DeclarationsChangelog {
+    private String collection = "declarations";
+
+    @ChangeSet(order = "001", id = "CEDS-2111 Change declaration types to APPLES", author = "Paulo Monteiro")
+    public void updateAllDeclarationTypeToApples(DB db) {
+        Document query = new Document("type", "STANDARD");
+        Document update = new Document("$set", new Document("additionalDeclarationType", "APPLES"));
+        db.getCollection(collection).update(new BasicDBObject(query), new BasicDBObject(update), false, true);
+    }
+
+    @ChangeSet(order = "002", id = "CEDS-2111 Move LRN to root of document", author = "Paulo Monteiro")
+    public void moveLRNToRootOfDocument(DB db) {
+
+        Document query = new Document("consignmentReferences.lrn", new Document("$exists", true));
+        DBCursor cursor = db.getCollection(collection).find(new BasicDBObject(query));
+        while (cursor.hasNext()) {
+            DBObject dbObject = cursor.next();
+
+            BasicDBObject consignmentReferences = (BasicDBObject) dbObject.get("consignmentReferences");
+            Document updateSet = new Document("$set", new Document("lrn", consignmentReferences).get("lrn"));
+            db.getCollection(collection).update(new BasicDBObject(query), new BasicDBObject(updateSet), false, true);
+
+            Document updateUnset = new Document("$unset", new Document("consignmentReferences.lrn", null));
+            db.getCollection(collection).update(new BasicDBObject(query), new BasicDBObject(updateUnset), false, true);
+        }
+    }
+}

--- a/app/uk/gov/hmrc/exports/mongobee/changesets/DeclarationsChangelog.java
+++ b/app/uk/gov/hmrc/exports/mongobee/changesets/DeclarationsChangelog.java
@@ -18,37 +18,13 @@ package uk.gov.hmrc.exports.mongobee.changesets;
 
 import com.github.mongobee.changeset.ChangeLog;
 import com.github.mongobee.changeset.ChangeSet;
-import com.mongodb.BasicDBObject;
 import com.mongodb.DB;
-import com.mongodb.DBCursor;
-import com.mongodb.DBObject;
-import org.bson.Document;
 
 @ChangeLog
 public class DeclarationsChangelog {
     private String collection = "declarations";
 
-    @ChangeSet(order = "001", id = "CEDS-2111 Change declaration types to APPLES", author = "Paulo Monteiro")
-    public void updateAllDeclarationTypeToApples(DB db) {
-        Document query = new Document("type", "STANDARD");
-        Document update = new Document("$set", new Document("additionalDeclarationType", "APPLES"));
-        db.getCollection(collection).update(new BasicDBObject(query), new BasicDBObject(update), false, true);
-    }
-
-    @ChangeSet(order = "002", id = "CEDS-2111 Move LRN to root of document", author = "Paulo Monteiro")
-    public void moveLRNToRootOfDocument(DB db) {
-
-        Document query = new Document("consignmentReferences.lrn", new Document("$exists", true));
-        DBCursor cursor = db.getCollection(collection).find(new BasicDBObject(query));
-        while (cursor.hasNext()) {
-            DBObject dbObject = cursor.next();
-
-            BasicDBObject consignmentReferences = (BasicDBObject) dbObject.get("consignmentReferences");
-            Document updateSet = new Document("$set", new Document("lrn", consignmentReferences).get("lrn"));
-            db.getCollection(collection).update(new BasicDBObject(query), new BasicDBObject(updateSet), false, true);
-
-            Document updateUnset = new Document("$unset", new Document("consignmentReferences.lrn", null));
-            db.getCollection(collection).update(new BasicDBObject(query), new BasicDBObject(updateUnset), false, true);
-        }
+    @ChangeSet(order = "001", id = "Exports DB Baseline", author = "Paulo Monteiro")
+    public void dbBaseline(DB db) {
     }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,20 +7,20 @@ object AppDependencies {
   private val testScope = "test, it, component"
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.22.0-play-26",
+    "uk.gov.hmrc"             %%  "simple-reactivemongo"  % "7.22.0-play-26",
     ws,
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.3.0",
-    "uk.gov.hmrc" %% "wco-dec" % "0.33.0",
-    "uk.gov.hmrc" %% "logback-json-logger" % "4.6.0",
-    "com.typesafe.play" %% "play-json-joda" % "2.6.10"
+    "uk.gov.hmrc"             %%  "bootstrap-play-26"     % "1.3.0",
+    "uk.gov.hmrc"             %%  "wco-dec"               % "0.33.0",
+    "uk.gov.hmrc"             %%  "logback-json-logger"   % "4.6.0",
+    "com.typesafe.play"       %%  "play-json-joda"        % "2.6.10"
   )
 
   def test(scope: String = "test") = Seq(
-    "org.scalatest" %% "scalatest" % "3.0.8" % testScope,
-    "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % testScope,
-    "com.github.tomakehurst" % "wiremock-jre8" % "2.25.1" % testScope,
-    "org.pegdown" % "pegdown" % "1.6.0" % testScope,
-    "com.typesafe.play" %% "play-test" % PlayVersion.current % testScope,
-    "org.mockito" % "mockito-core" % "3.0.0" % "test"
+    "org.scalatest"           %% "scalatest"            % "3.0.8"             % testScope,
+    "org.scalatestplus.play"  %% "scalatestplus-play"   % "3.1.2"             % testScope,
+    "com.github.tomakehurst"  % "wiremock-jre8"         % "2.25.1"            % testScope,
+    "org.pegdown"             % "pegdown"               % "1.6.0"             % testScope,
+    "com.typesafe.play"       %% "play-test"            % PlayVersion.current % testScope,
+    "org.mockito"             % "mockito-core"          % "3.0.0"             % "test"
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -12,7 +12,8 @@ object AppDependencies {
     "uk.gov.hmrc"             %%  "bootstrap-play-26"     % "1.3.0",
     "uk.gov.hmrc"             %%  "wco-dec"               % "0.33.0",
     "uk.gov.hmrc"             %%  "logback-json-logger"   % "4.6.0",
-    "com.typesafe.play"       %%  "play-json-joda"        % "2.6.10"
+    "com.typesafe.play"       %%  "play-json-joda"        % "2.6.10",
+    "com.github.mongobee"     %   "mongobee"              % "0.13"
   )
 
   def test(scope: String = "test") = Seq(

--- a/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
@@ -30,6 +30,7 @@ class AppConfigSpec extends WordSpec with Matchers with MockitoSugar {
   private val validAppConfig: Config =
     ConfigFactory.parseString("""
       |urls.login="http://localhost:9949/auth-login-stub/gg-sign-in"
+      |mongodb.uri="mongodb://localhost:27017/customs-declare-exports"
       |microservice.services.auth.host=localhostauth
       |microservice.services.auth.port=9988
       |microservice.services.customs-declarations.host=remotedec-api
@@ -40,9 +41,12 @@ class AppConfigSpec extends WordSpec with Matchers with MockitoSugar {
       |microservice.services.customs-declarations.bearer-token=Bearer DummyBearerToken
     """.stripMargin)
 
+  private val invalidAppConfig: Config = ConfigFactory.parseString("""
+      |mongodb.uri="mongodb://localhost:27017/customs-declare-exports"
+      |""".stripMargin)
   private val emptyAppConfig: Config = ConfigFactory.parseString("")
   private val validServicesConfiguration = Configuration(validAppConfig)
-  private val emptyServicesConfiguration = Configuration(emptyAppConfig)
+  private val invalidServicesConfiguration = Configuration(invalidAppConfig)
 
   val environment = Environment.simple()
 
@@ -64,7 +68,7 @@ class AppConfigSpec extends WordSpec with Matchers with MockitoSugar {
     }
 
     "throw an exception when mandatory configuration is invalid" in {
-      val configService: AppConfig = appConfig(emptyServicesConfiguration)
+      val configService: AppConfig = appConfig(invalidServicesConfiguration)
 
       val caught: RuntimeException = intercept[RuntimeException](configService.authUrl)
       caught.getMessage shouldBe "Could not find config auth.host"
@@ -94,7 +98,13 @@ class AppConfigSpec extends WordSpec with Matchers with MockitoSugar {
 
       "return the configured value when explicitly set" in {
         val configService: AppConfig =
-          appConfig(Configuration("appName" -> appName, "microservice.services.customs-declarations.client-id" -> clientId))
+          appConfig(
+            Configuration(
+              "appName" -> appName,
+              "microservice.services.customs-declarations.client-id" -> clientId,
+              "mongodb.uri" -> "mongodb://localhost:27017/customs-declare-exports"
+            )
+          )
 
         configService.developerHubClientId shouldBe clientId
       }


### PR DESCRIPTION
* Pretty format the AppDependencies
* Add Mongobee as our DB migration tool

This PR provides a simple example of how we would update all the existing `additionalDeclarationType` fields from `D` to `A`

The Spike work can be found here (https://confluence.tools.tax.service.gov.uk/pages/viewpage.action?pageId=179472929) for more details.

This uses Mongobee - https://github.com/mongobee/mongobee