### PR TITLE
CEDS-2191 - Change validation on Commodity Measurements page for Clearance Requests

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
@@ -100,7 +100,7 @@ object PackageInformation {
   implicit val format: OFormat[PackageInformation] = Json.format[PackageInformation]
 }
 
-case class CommodityMeasure(supplementaryUnits: Option[String], netMass: String, grossMass: String)
+case class CommodityMeasure(supplementaryUnits: Option[String], netMass: Option[String], grossMass: Option[String])
 object CommodityMeasure {
   implicit val format: OFormat[CommodityMeasure] = Json.format[CommodityMeasure]
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/CachingMappingHelper.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/CachingMappingHelper.scala
@@ -51,11 +51,16 @@ class CachingMappingHelper {
         taricCodes.map(code => Classification(Some(code), identificationTypeCode = Some(TARICAdditionalCode.value)))
     ).toSeq
 
-  def mapGoodsMeasure(data: CommodityMeasure) =
-    Commodity(
-      goodsMeasure =
-        Some(GoodsMeasure(Some(createMeasure(data.grossMass)), Some(createMeasure(data.netMass)), data.supplementaryUnits.map(createMeasure)))
-    )
+  def mapGoodsMeasure(data: CommodityMeasure): Option[Commodity] = data match {
+    case CommodityMeasure(None, None, None) => None
+    case _ =>
+      Some(
+        Commodity(
+          goodsMeasure =
+            Some(GoodsMeasure(data.grossMass.map(createMeasure), data.netMass.map(createMeasure), data.supplementaryUnits.map(createMeasure)))
+        )
+      )
+  }
 
   private def createMeasure(unitValue: String) =
     try {

--- a/app/uk/gov/hmrc/exports/services/mapping/CachingMappingHelper.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/CachingMappingHelper.scala
@@ -53,12 +53,9 @@ class CachingMappingHelper {
 
   def mapGoodsMeasure(data: CommodityMeasure): Option[Commodity] = data match {
     case CommodityMeasure(None, None, None) => None
-    case _ =>
+    case CommodityMeasure(supplementaryUnits, netMass, grossMass) =>
       Some(
-        Commodity(
-          goodsMeasure =
-            Some(GoodsMeasure(data.grossMass.map(createMeasure), data.netMass.map(createMeasure), data.supplementaryUnits.map(createMeasure)))
-        )
+        Commodity(goodsMeasure = Some(GoodsMeasure(grossMass.map(createMeasure), netMass.map(createMeasure), supplementaryUnits.map(createMeasure))))
       )
   }
 

--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
@@ -76,7 +76,7 @@ class GovernmentAgencyGoodsItemBuilder @Inject()(
 
   private def mapCommodityMeasureToCommodity(commodityMeasure: Option[CommodityMeasure], declarationType: DeclarationType): Option[Commodity] =
     if (journeysWithCommodityMeasurements.contains(declarationType)) {
-      commodityMeasure.map(measure => cachingMappingHelper.mapGoodsMeasure(measure))
+      commodityMeasure.flatMap(measure => cachingMappingHelper.mapGoodsMeasure(measure))
     } else None
 
   private def combineCommodities(commodityPart1: Commodity, commodityPart2: Option[Commodity]): Commodity =

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/CachingMappingHelperSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/CachingMappingHelperSpec.scala
@@ -25,8 +25,8 @@ class CachingMappingHelperSpec extends WordSpec with Matchers {
   "CachingMappingHelper" should {
     "mapGoodsMeasure correctly When tariffQuantity grossMassMeasure netWeightMeasure provided" in {
 
-      val commodityMeasure = CommodityMeasure(Some("10"), "100.00", "100.00")
-      val goodsMeasure = new CachingMappingHelper().mapGoodsMeasure(commodityMeasure).goodsMeasure.get
+      val commodityMeasure = CommodityMeasure(Some("10"), Some("100.00"), Some("100.00"))
+      val goodsMeasure = new CachingMappingHelper().mapGoodsMeasure(commodityMeasure).flatMap(_.goodsMeasure).get
 
       goodsMeasure.tariffQuantity.get.value.get shouldBe 10
       goodsMeasure.grossMassMeasure.get.value.get shouldBe 100.00
@@ -35,12 +35,19 @@ class CachingMappingHelperSpec extends WordSpec with Matchers {
 
     "mapGoodsMeasure correctly When grossMassMeasure netWeightMeasure provided but no tariffQuantity" in {
 
-      val commodityMeasure = CommodityMeasure(None, "100.00", "100.00")
+      val commodityMeasure = CommodityMeasure(None, Some("100.00"), Some("100.00"))
 
-      val goodsMeasure = new CachingMappingHelper().mapGoodsMeasure(commodityMeasure).goodsMeasure.get
+      val goodsMeasure = new CachingMappingHelper().mapGoodsMeasure(commodityMeasure).flatMap(_.goodsMeasure).get
       goodsMeasure.tariffQuantity shouldBe None
       goodsMeasure.grossMassMeasure.get.value.get shouldBe 100.00
       goodsMeasure.netWeightMeasure.get.value.get shouldBe 100.00
+    }
+
+    "mapGoodsMeasure correctly When no fields are provided" in {
+
+      val commodityMeasure = CommodityMeasure(None, None, None)
+
+      new CachingMappingHelper().mapGoodsMeasure(commodityMeasure) shouldBe None
     }
 
     "mapCommodity" when {

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
@@ -65,7 +65,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
         s"on the $declarationType journey" in {
           val exportItem = anItem(
             withSequenceId(99),
-            withCommodityMeasure(CommodityMeasure(Some("2"), "90", "100")),
+            withCommodityMeasure(CommodityMeasure(Some("2"), Some("90"), Some("100"))),
             withAdditionalFiscalReferenceData(AdditionalFiscalReferences(Seq(AdditionalFiscalReference("GB", "reference")))),
             withStatisticalValue(statisticalValue = "123"),
             withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("classificationsId"), descriptionOfGoods = "commodityDescription"))
@@ -74,7 +74,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
             aDeclaration(withType(declarationType), withItem(exportItem), withOfficeOfExit(presentationOfficeId = Some("id")))
 
           when(mockCachingMappingHelper.mapGoodsMeasure(any[CommodityMeasure]))
-            .thenReturn(Commodity(description = Some("Some Commodity")))
+            .thenReturn(Some(Commodity(description = Some("Some Commodity"))))
           when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Commodity(description = Some("Some Commodity")))
 
           val goodsShipment = new GoodsShipment
@@ -100,7 +100,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
         s"on the $declarationType journey" in {
           val exportItem = anItem(
             withSequenceId(99),
-            withCommodityMeasure(CommodityMeasure(Some("2"), "90", "100")),
+            withCommodityMeasure(CommodityMeasure(Some("2"), Some("90"), Some("100"))),
             withAdditionalFiscalReferenceData(AdditionalFiscalReferences(Seq(AdditionalFiscalReference("GB", "reference")))),
             withStatisticalValue(statisticalValue = "123"),
             withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("classificationsId"), descriptionOfGoods = "commodityDescription"))
@@ -109,7 +109,7 @@ class GovernmentAgencyGoodsItemBuilderSpec
             aDeclaration(withType(declarationType), withItem(exportItem), withOfficeOfExit(presentationOfficeId = Some("id")))
 
           when(mockCachingMappingHelper.mapGoodsMeasure(any[CommodityMeasure]))
-            .thenReturn(Commodity(description = Some("Some Commodity")))
+            .thenReturn(Some(Commodity(description = Some("Some Commodity"))))
           when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Commodity(description = Some("Some Commodity")))
 
           val goodsShipment = new GoodsShipment

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemData.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemData.scala
@@ -51,7 +51,7 @@ trait GovernmentAgencyGoodsItemData {
   val netMassString = "15.00"
   val grossMassString = "25.00"
   val tariffQuantity = "31"
-  val commodityMeasure = CommodityMeasure(Some(tariffQuantity), netMass = netMassString, grossMass = grossMassString)
+  val commodityMeasure = CommodityMeasure(Some(tariffQuantity), netMass = Some(netMassString), grossMass = Some(grossMassString))
 
   //procedureCodes Data
 

--- a/test/util/stubs/SeedMongo.scala
+++ b/test/util/stubs/SeedMongo.scala
@@ -70,7 +70,7 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
         withStatisticalValue(statisticalValue = "1000"),
         withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("46021910"), descriptionOfGoods = "Straw for bottles")),
         withPackageInformation("PK", 10, "RICH123"),
-        withCommodityMeasure(CommodityMeasure(Some("10"), "500", "700")),
+        withCommodityMeasure(CommodityMeasure(Some("10"), Some("500"), Some("700"))),
         withAdditionalInformation("00400", "EXPORTER"),
         withDocumentsProduced(DocumentProduced(Some("C501"), Some("GBAEOC71757250450281"), None, None, None, None, None))
       )


### PR DESCRIPTION
This PR makes gross and net weights on the CommodityMeasure optional.  I've tested that this BE change is compatible with the existing FE by creating a draft declaration with the existing BE then switching to this branch and completing the dec and submitting it.  (i.e. db upgrades are not necessary).

Only thing that I can't check is that we can eventually submit a clearance declaration without a CommodityMeasure.   It _should_ work because the wco `Commodity` that we create is optional (both in the wco library and the customs_declaration XSD).  But that will need to be verified once we have completed and deployed the FE changes for clearance requests to QA