### PR TITLE
CEDS-2190 Change all PackageInformation fields to be optional

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
@@ -95,7 +95,7 @@ object IdentificationTypeCodes {
   }
 }
 
-case class PackageInformation(typesOfPackages: String, numberOfPackages: Int, shippingMarks: String)
+case class PackageInformation(typesOfPackages: Option[String], numberOfPackages: Option[Int], shippingMarks: Option[String])
 object PackageInformation {
   implicit val format: OFormat[PackageInformation] = Json.format[PackageInformation]
 }
@@ -105,7 +105,7 @@ object CommodityMeasure {
   implicit val format: OFormat[CommodityMeasure] = Json.format[CommodityMeasure]
 }
 
-case class AdditionalInformation(code: String, description: String) {}
+case class AdditionalInformation(code: String, description: String)
 object AdditionalInformation {
   implicit val format: OFormat[AdditionalInformation] = Json.format[AdditionalInformation]
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/PackagingBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/PackagingBuilder.scala
@@ -32,22 +32,33 @@ class PackagingBuilder @Inject()() extends ModifyingBuilder[ExportItem, GoodsShi
           .add(createWcoPackaging(index, packing.typesOfPackages, packing.numberOfPackages, packing.shippingMarks))
     }
 
-  private def createWcoPackaging(sequenceNumeric: Int, typeCode: String, quantity: Int, markNumber: String): Packaging = {
+  private def createWcoPackaging(
+    sequenceNumeric: Int,
+    typeCodeOpt: Option[String],
+    quantityOpt: Option[Int],
+    markNumberOpt: Option[String]
+  ): Packaging = {
     val wcoPackaging = new Packaging
 
-    val packagingTypeCodeType = new PackagingTypeCodeType
-    packagingTypeCodeType.setValue(typeCode)
-    wcoPackaging.setTypeCode(packagingTypeCodeType)
+    typeCodeOpt.foreach { typeCode =>
+      val packagingTypeCodeType = new PackagingTypeCodeType
+      packagingTypeCodeType.setValue(typeCode)
+      wcoPackaging.setTypeCode(packagingTypeCodeType)
+    }
 
-    val packagingQuantityQuantityType = new PackagingQuantityQuantityType
-    //TODO noticed here that quantity type in old scala wco is not captured.. no cannot set :-
-    // packagingQuantityQuantityType.setUnitCode(????)
-    packagingQuantityQuantityType.setValue(new java.math.BigDecimal(quantity))
-    wcoPackaging.setQuantityQuantity(packagingQuantityQuantityType)
+    quantityOpt.foreach { quantity =>
+      val packagingQuantityQuantityType = new PackagingQuantityQuantityType
+      //TODO noticed here that quantity type in old scala wco is not captured.. no cannot set :-
+      // packagingQuantityQuantityType.setUnitCode(????)
+      packagingQuantityQuantityType.setValue(new java.math.BigDecimal(quantity))
+      wcoPackaging.setQuantityQuantity(packagingQuantityQuantityType)
+    }
 
-    val packagingMarksNumbersIDType = new PackagingMarksNumbersIDType
-    packagingMarksNumbersIDType.setValue(markNumber)
-    wcoPackaging.setMarksNumbersID(packagingMarksNumbersIDType)
+    markNumberOpt.foreach { markNumber =>
+      val packagingMarksNumbersIDType = new PackagingMarksNumbersIDType
+      packagingMarksNumbersIDType.setValue(markNumber)
+      wcoPackaging.setMarksNumbersID(packagingMarksNumbersIDType)
+    }
 
     wcoPackaging.setSequenceNumeric(new java.math.BigDecimal(sequenceNumeric))
 

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/ExportsItemBuilder.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/ExportsItemBuilder.scala
@@ -71,7 +71,11 @@ trait ExportsItemBuilder {
   def withPackageInformation(informations: List[PackageInformation]): ItemModifier =
     _.copy(packageInformation = Some(informations))
 
-  def withPackageInformation(typesOfPackages: String = "", numberOfPackages: Int = 0, shippingMarks: String = ""): ItemModifier =
+  def withPackageInformation(
+    typesOfPackages: Option[String] = None,
+    numberOfPackages: Option[Int] = None,
+    shippingMarks: Option[String] = None
+  ): ItemModifier =
     cache =>
       cache.copy(
         packageInformation =

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemData.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemData.scala
@@ -40,7 +40,7 @@ trait GovernmentAgencyGoodsItemData {
   val packageTypeValue = "packageType"
   val numberOfPackages = 12
 
-  val packageInformation = new PackageInformation(packageTypeValue, numberOfPackages, shippingMarks)
+  val packageInformation = new PackageInformation(Some(packageTypeValue), Some(numberOfPackages), Some(shippingMarks))
 
   //Item Type Data
   val descriptionOfGoods = "descriptionOfGoods"

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/PackagingBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/PackagingBuilderSpec.scala
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-package unit.uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
+package uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
 
 import org.scalatest.{Matchers, WordSpec}
-import uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem.PackagingBuilder
 import unit.uk.gov.hmrc.exports.services.mapping.ExportsItemBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
 
 class PackagingBuilderSpec extends WordSpec with Matchers with ExportsItemBuilder {
 
+  private def builder = new PackagingBuilder()
+
   "PackageBuilder" should {
 
     "build then add" when {
+
       "empty list" in {
         val model = anItem(withoutPackageInformation())
         val wcoItem = new GoodsShipment.GovernmentAgencyGoodsItem()
@@ -36,7 +38,7 @@ class PackagingBuilderSpec extends WordSpec with Matchers with ExportsItemBuilde
       }
 
       "populated list" in {
-        val model = anItem(withPackageInformation("types", 123, "marks"))
+        val model = anItem(withPackageInformation(Some("types"), Some(123), Some("marks")))
         val wcoItem = new GoodsShipment.GovernmentAgencyGoodsItem()
 
         builder.buildThenAdd(model, wcoItem)
@@ -50,5 +52,4 @@ class PackagingBuilderSpec extends WordSpec with Matchers with ExportsItemBuilde
     }
   }
 
-  private def builder = new PackagingBuilder()
 }

--- a/test/util/stubs/SeedMongo.scala
+++ b/test/util/stubs/SeedMongo.scala
@@ -19,9 +19,9 @@ package stubs
 import java.util.UUID
 
 import reactivemongo.api.{MongoConnection, MongoDriver}
+import testdata.ExportsDeclarationBuilder
 import uk.gov.hmrc.exports.models.declaration._
 import unit.uk.gov.hmrc.exports.services.mapping.ExportsItemBuilder
-import testdata.ExportsDeclarationBuilder
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
@@ -60,7 +60,7 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
         withProcedureCodes(Some("1040"), Seq("000")),
         withStatisticalValue(statisticalValue = "1000"),
         withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("46021910"), descriptionOfGoods = "Straw for bottles")),
-        withPackageInformation("PK", 10, "RICH123"),
+        withPackageInformation(Some("PK"), Some(10), Some("RICH123")),
         withCommodityMeasure(CommodityMeasure(Some("10"), Some("500"), Some("700"))),
         withAdditionalInformation("00400", "EXPORTER"),
         withDocumentsProduced(DocumentProduced(Some("C501"), Some("GBAEOC71757250450281"), None, None, None, None, None))


### PR DESCRIPTION
For one type of declaration all the fields in PackageInformation are
non-mandatory. Since the model is shared between all declaration types,
it needs to allow 'empty' values.
From another perspective, the target schema has these fields as optional
as well.