### PR TITLE
CEDS-2189 Make CommodityDetails.descriptionOfGoods optional

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportItem.scala
@@ -43,7 +43,7 @@ object AdditionalFiscalReferences {
   implicit val format: OFormat[AdditionalFiscalReferences] = Json.format[AdditionalFiscalReferences]
 }
 
-case class CommodityDetails(combinedNomenclatureCode: Option[String], descriptionOfGoods: String)
+case class CommodityDetails(combinedNomenclatureCode: Option[String], descriptionOfGoods: Option[String])
 object CommodityDetails {
   implicit val format: OFormat[CommodityDetails] = Json.format[CommodityDetails]
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
@@ -72,7 +72,7 @@ class GovernmentAgencyGoodsItemBuilder @Inject()(
     combinedCommodity.foreach(commodityBuilder.buildThenAdd(_, wcoGovernmentAgencyGoodsItem))
   }
   private def mapExportItemToCommodity(exportItem: ExportItem): Option[Commodity] =
-    exportItem.commodityDetails.map(_ => cachingMappingHelper.commodityFromExportItem(exportItem))
+    exportItem.commodityDetails.flatMap(_ => cachingMappingHelper.commodityFromExportItem(exportItem))
 
   private def mapCommodityMeasureToCommodity(commodityMeasure: Option[CommodityMeasure], declarationType: DeclarationType): Option[Commodity] =
     if (journeysWithCommodityMeasurements.contains(declarationType)) {

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
@@ -68,14 +68,16 @@ class GovernmentAgencyGoodsItemBuilderSpec
             withCommodityMeasure(CommodityMeasure(Some("2"), Some("90"), Some("100"))),
             withAdditionalFiscalReferenceData(AdditionalFiscalReferences(Seq(AdditionalFiscalReference("GB", "reference")))),
             withStatisticalValue(statisticalValue = "123"),
-            withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("classificationsId"), descriptionOfGoods = "commodityDescription"))
+            withCommodityDetails(
+              CommodityDetails(combinedNomenclatureCode = Some("classificationsId"), descriptionOfGoods = Some("commodityDescription"))
+            )
           )
           val exportsDeclaration =
             aDeclaration(withType(declarationType), withItem(exportItem), withOfficeOfExit(presentationOfficeId = Some("id")))
 
           when(mockCachingMappingHelper.mapGoodsMeasure(any[CommodityMeasure]))
             .thenReturn(Some(Commodity(description = Some("Some Commodity"))))
-          when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Commodity(description = Some("Some Commodity")))
+          when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Some(Commodity(description = Some("Some Commodity"))))
 
           val goodsShipment = new GoodsShipment
           builder.buildThenAdd(exportsDeclaration, goodsShipment)
@@ -103,14 +105,16 @@ class GovernmentAgencyGoodsItemBuilderSpec
             withCommodityMeasure(CommodityMeasure(Some("2"), Some("90"), Some("100"))),
             withAdditionalFiscalReferenceData(AdditionalFiscalReferences(Seq(AdditionalFiscalReference("GB", "reference")))),
             withStatisticalValue(statisticalValue = "123"),
-            withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("classificationsId"), descriptionOfGoods = "commodityDescription"))
+            withCommodityDetails(
+              CommodityDetails(combinedNomenclatureCode = Some("classificationsId"), descriptionOfGoods = Some("commodityDescription"))
+            )
           )
           val exportsDeclaration =
             aDeclaration(withType(declarationType), withItem(exportItem), withOfficeOfExit(presentationOfficeId = Some("id")))
 
           when(mockCachingMappingHelper.mapGoodsMeasure(any[CommodityMeasure]))
             .thenReturn(Some(Commodity(description = Some("Some Commodity"))))
-          when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Commodity(description = Some("Some Commodity")))
+          when(mockCachingMappingHelper.commodityFromExportItem(any[ExportItem])).thenReturn(Some(Commodity(description = Some("Some Commodity"))))
 
           val goodsShipment = new GoodsShipment
           builder.buildThenAdd(exportsDeclaration, goodsShipment)

--- a/test/util/stubs/SeedMongo.scala
+++ b/test/util/stubs/SeedMongo.scala
@@ -59,7 +59,7 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
       anItem(
         withProcedureCodes(Some("1040"), Seq("000")),
         withStatisticalValue(statisticalValue = "1000"),
-        withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("46021910"), descriptionOfGoods = "Straw for bottles")),
+        withCommodityDetails(CommodityDetails(combinedNomenclatureCode = Some("46021910"), descriptionOfGoods = Some("Straw for bottles"))),
         withPackageInformation(Some("PK"), Some(10), Some("RICH123")),
         withCommodityMeasure(CommodityMeasure(Some("10"), Some("500"), Some("700"))),
         withAdditionalInformation("00400", "EXPORTER"),


### PR DESCRIPTION
For Clearance Requests, data elements '6/14 Commodity code' and
'6/8 Description of Goods' are not required in the majority of cases.

This data element is not required on clearance requests using procedure
codes 00 18 or 00 19 in D.E. 1/10.

**Relates to https://github.com/hmrc/customs-declare-exports-frontend/pull/788**