### PR TITLE
CEDS-2192 - ignore in-applicable means of transport on departure type

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/Transport.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Transport.scala
@@ -38,11 +38,12 @@ case class Transport(
 
   def hasDepartureTransportDetails: Boolean =
     meansOfTransportOnDepartureIDNumber.nonEmpty || meansOfTransportOnDepartureType.nonEmpty
+
+  def isMeansOfTransportOnDepartureDefined: Boolean = meansOfTransportOnDepartureType.exists(_ != Transport.optionNone)
 }
 
 object Transport {
   implicit val format: OFormat[Transport] = Json.format[Transport]
 
   val optionNone = "option_none"
-  def typeApplicable(value: String): Boolean = value != optionNone
 }

--- a/app/uk/gov/hmrc/exports/models/declaration/Transport.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Transport.scala
@@ -42,4 +42,7 @@ case class Transport(
 
 object Transport {
   implicit val format: OFormat[Transport] = Json.format[Transport]
+
+  val optionNone = "option_none"
+  def typeApplicable(value: String): Boolean = value != optionNone
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilder.scala
@@ -44,17 +44,17 @@ class DepartureTransportMeansBuilder @Inject()() {
       departureTransportMeans.setModeCode(modeCodeType)
     }
 
-    transport.meansOfTransportOnDepartureType.foreach { transportType =>
-      if (Transport.typeApplicable(transportType)) {
-        val identificationTypeCode = new DepartureTransportMeansIdentificationTypeCodeType()
-        identificationTypeCode.setValue(transportType)
-        departureTransportMeans.setIdentificationTypeCode(identificationTypeCode)
+    if (transport.isMeansOfTransportOnDepartureDefined) {
+      transport.meansOfTransportOnDepartureIDNumber.foreach { value =>
+        val id = new DepartureTransportMeansIdentificationIDType()
+        id.setValue(value)
+        departureTransportMeans.setID(id)
+      }
 
-        transport.meansOfTransportOnDepartureIDNumber.foreach { value =>
-          val id = new DepartureTransportMeansIdentificationIDType()
-          id.setValue(value)
-          departureTransportMeans.setID(id)
-        }
+      transport.meansOfTransportOnDepartureType.foreach { value =>
+        val identificationTypeCode = new DepartureTransportMeansIdentificationTypeCodeType()
+        identificationTypeCode.setValue(value)
+        departureTransportMeans.setIdentificationTypeCode(identificationTypeCode)
       }
     }
 

--- a/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilder.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment
 
 import javax.inject.Inject
-import uk.gov.hmrc.exports.models.declaration.{DepartureTransport, InlandModeOfTransportCode, Transport}
+import uk.gov.hmrc.exports.models.declaration.{InlandModeOfTransportCode, Transport}
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Consignment
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Consignment.DepartureTransportMeans
 import wco.datamodel.wco.declaration_ds.dms._2.{
@@ -44,16 +44,18 @@ class DepartureTransportMeansBuilder @Inject()() {
       departureTransportMeans.setModeCode(modeCodeType)
     }
 
-    transport.meansOfTransportOnDepartureIDNumber.foreach { value =>
-      val id = new DepartureTransportMeansIdentificationIDType()
-      id.setValue(value)
-      departureTransportMeans.setID(id)
-    }
+    transport.meansOfTransportOnDepartureType.foreach { transportType =>
+      if (Transport.typeApplicable(transportType)) {
+        val identificationTypeCode = new DepartureTransportMeansIdentificationTypeCodeType()
+        identificationTypeCode.setValue(transportType)
+        departureTransportMeans.setIdentificationTypeCode(identificationTypeCode)
 
-    transport.meansOfTransportOnDepartureType.foreach { value =>
-      val identificationTypeCode = new DepartureTransportMeansIdentificationTypeCodeType()
-      identificationTypeCode.setValue(value)
-      departureTransportMeans.setIdentificationTypeCode(identificationTypeCode)
+        transport.meansOfTransportOnDepartureIDNumber.foreach { value =>
+          val id = new DepartureTransportMeansIdentificationIDType()
+          id.setValue(value)
+          departureTransportMeans.setID(id)
+        }
+      }
     }
 
     departureTransportMeans

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilderSpec.scala
@@ -17,9 +17,9 @@
 package unit.uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment
 
 import org.scalatest.{Matchers, WordSpec}
-import uk.gov.hmrc.exports.models.declaration.{DepartureTransport, InlandModeOfTransportCode, Transport}
-import uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment.DepartureTransportMeansBuilder
 import testdata.ExportsDeclarationBuilder
+import uk.gov.hmrc.exports.models.declaration.{InlandModeOfTransportCode, Transport}
+import uk.gov.hmrc.exports.services.mapping.goodsshipment.consignment.DepartureTransportMeansBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
 
 class DepartureTransportMeansBuilderSpec extends WordSpec with Matchers with ExportsDeclarationBuilder {
@@ -45,6 +45,31 @@ class DepartureTransportMeansBuilderSpec extends WordSpec with Matchers with Exp
       val departureTransportMeans = consignment.getDepartureTransportMeans
       departureTransportMeans.getID.getValue shouldBe meansOfTransportOnDepartureIDNumber
       departureTransportMeans.getIdentificationTypeCode.getValue shouldBe meansOfTransportOnDepartureType
+      departureTransportMeans.getModeCode.getValue shouldBe inlandModeOfTransport
+      departureTransportMeans.getName shouldBe null
+      departureTransportMeans.getTypeCode shouldBe null
+    }
+
+    "not map inapplicable DepartureTransportMeans" in {
+      val borderModeOfTransportCode = "BCode"
+      val meansOfTransportOnDepartureType = Transport.optionNone
+      val meansOfTransportOnDepartureIDNumber = "ignore"
+      val inlandModeOfTransport = "1"
+
+      val builder = new DepartureTransportMeansBuilder
+
+      val transport = Transport(
+        borderModeOfTransportCode = Some(borderModeOfTransportCode),
+        meansOfTransportOnDepartureType = Some(meansOfTransportOnDepartureType),
+        meansOfTransportOnDepartureIDNumber = Some(meansOfTransportOnDepartureIDNumber)
+      )
+
+      val consignment = new GoodsShipment.Consignment
+      builder.buildThenAdd(transport, Some(InlandModeOfTransportCode(Some(inlandModeOfTransport))), consignment)
+
+      val departureTransportMeans = consignment.getDepartureTransportMeans
+      departureTransportMeans.getID shouldBe null
+      departureTransportMeans.getIdentificationTypeCode shouldBe null
       departureTransportMeans.getModeCode.getValue shouldBe inlandModeOfTransport
       departureTransportMeans.getName shouldBe null
       departureTransportMeans.getTypeCode shouldBe null


### PR DESCRIPTION
This is the companion PR to https://github.com/hmrc/customs-declare-exports-frontend/pull/793
It simply discards the means of transport on departure information if the user selected the "not applicable" or none option when building the XML payload.