### PR TITLE
CEDS-2249 - Make 'Office of Exit' optional for Clearance Requests

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/Locations.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Locations.scala
@@ -23,7 +23,7 @@ object GoodsLocation {
   implicit val format: OFormat[GoodsLocation] = Json.format[GoodsLocation]
 }
 
-case class OfficeOfExit(officeId: String, presentationOfficeId: Option[String], circumstancesCode: Option[String])
+case class OfficeOfExit(officeId: Option[String], presentationOfficeId: Option[String], circumstancesCode: Option[String])
 object OfficeOfExit {
   implicit val format: OFormat[OfficeOfExit] = Json.format[OfficeOfExit]
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilder.scala
@@ -29,13 +29,14 @@ class ExitOfficeBuilder @Inject()() extends ModifyingBuilder[ExportsDeclaration,
     case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY | DeclarationType.SIMPLIFIED | DeclarationType.OCCASIONAL |
         DeclarationType.CLEARANCE =>
       model.locations.officeOfExit
-        .map(build)
+        .flatMap(_.officeId)
+        .map(createExitOffice)
         .foreach(declaration.setExitOffice)
   }
 
-  private def build(data: OfficeOfExit): Declaration.ExitOffice = {
+  private def createExitOffice(value: String): Declaration.ExitOffice = {
     val officeIdentificationIDType = new ExitOfficeIdentificationIDType()
-    officeIdentificationIDType.setValue(data.officeId)
+    officeIdentificationIDType.setValue(value)
 
     val exitOffice = new ExitOffice()
     exitOffice.setID(officeIdentificationIDType)

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExitOfficeBuilderSpec.scala
@@ -45,12 +45,25 @@ class ExitOfficeBuilderSpec extends WordSpec with Matchers with ExportsDeclarati
         }
 
         s"$declarationType journey with populated data" in {
-          val model = aDeclaration(withType(declarationType), withOfficeOfExit(officeId = "office-id"))
+          val model = aDeclaration(withType(declarationType), withOfficeOfExit(officeId = Some("office-id")))
           val declaration = new Declaration()
 
           builder.buildThenAdd(model, declaration)
 
           declaration.getExitOffice.getID.getValue should be("office-id")
+        }
+      }
+    }
+
+    "build then add for clearance request with no office id" when {
+      for (declarationType: DeclarationType <- Seq(DeclarationType.CLEARANCE)) {
+        s"$declarationType journey with populated data" in {
+          val model = aDeclaration(withType(declarationType), withOfficeOfExit(officeId = None))
+          val declaration = new Declaration()
+
+          builder.buildThenAdd(model, declaration)
+
+          declaration.getExitOffice should be(null)
         }
       }
     }

--- a/test/util/stubs/SeedMongo.scala
+++ b/test/util/stubs/SeedMongo.scala
@@ -54,7 +54,7 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
     withWarehouseIdentification("RGBLBA001"),
     withSupervisingCustomsOffice("Belfast"),
     withInlandModeOfTransport("1"),
-    withOfficeOfExit("GB000054", Some("GBLBA003"), Some("No")),
+    withOfficeOfExit(Some("GB000054"), Some("GBLBA003"), Some("No")),
     withItems(
       anItem(
         withProcedureCodes(Some("1040"), Seq("000")),

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -199,7 +199,7 @@ trait ExportsDeclarationBuilder {
     cache => cache.copy(locations = cache.locations.copy(officeOfExit = None))
 
   def withOfficeOfExit(
-    officeId: String = "",
+    officeId: Option[String] = None,
     presentationOfficeId: Option[String] = None,
     circumstancesCode: Option[String] = None
   ): ExportsDeclarationModifier =


### PR DESCRIPTION
This PR makes the officeId part of OfficeOfExit optional in preparation for FE changes.
This change is OK to merge in first as it's compatible with existing (non-optional officeId) FE