### PR TITLE
BAU - Understand DB Migrations on Remove Environments

### DIFF
--- a/app/uk/gov/hmrc/exports/mongock/MongockConfig.scala
+++ b/app/uk/gov/hmrc/exports/mongock/MongockConfig.scala
@@ -27,7 +27,12 @@ case class MongockConfig(mongoURI: String) {
 
   val client = new MongoClient(uri)
 
+  val lockAcquiredForMinutes = 3
+  val maxWaitingForLockMinutes = 5
+  val maxTries = 10
+
   val runner = new MongockBuilder(client, uri.getDatabase, "uk.gov.hmrc.exports.mongock.changesets")
+    .setLockConfig(lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries)
     .build()
 
   runner.execute()


### PR DESCRIPTION
The default lock, locks the collection for DB migrations for 24 hours.
If the DB migration takes longer than a 3 minutes, for some reason the
connection to the collection is lost and the lock is never removed.

By providing a quick lock, it would allow the application to try and
acquire the lock at least up to 10 times.