### PR TITLE
BAU - Only do the migration if country name

### DIFF
--- a/app/uk/gov/hmrc/exports/mongock/changesets/JavaCacheChangeLog.java
+++ b/app/uk/gov/hmrc/exports/mongock/changesets/JavaCacheChangeLog.java
@@ -54,7 +54,8 @@ public class JavaCacheChangeLog {
                 .find(and(
                         exists("locations.goodsLocation.country"),
                         type("locations.goodsLocation.country", "string"),
-                        ne("locations.goodsLocation.country", "")))
+                        ne("locations.goodsLocation.country", ""),
+                        regex("locations.goodsLocation.country","^.{3,}$" )))
                 .forEach((Consumer<Document>) document -> {
                     // Retrieve indexes
                     String documentId = (String) document.get(INDEX_ID);


### PR DESCRIPTION
All country codes use the two-characters ISO code.
Looking at the length of the field we can determine which records
require a migration.
This avoids having to loop through documents already migrated.