### PR TITLE
CEDS-2250 Add tests for CacheChangeLog classes

### DIFF
--- a/app/uk/gov/hmrc/exports/mongock/MongockConfig.scala
+++ b/app/uk/gov/hmrc/exports/mongock/MongockConfig.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.exports.mongock
 
-import com.github.cloudyrock.mongock.MongockBuilder
+import com.github.cloudyrock.mongock.{Mongock, MongockBuilder}
 import com.google.inject.Singleton
 import com.mongodb.{MongoClient, MongoClientURI}
 
@@ -31,7 +31,7 @@ case class MongockConfig(mongoURI: String) {
   val maxWaitingForLockMinutes = 5
   val maxTries = 10
 
-  val runner = new MongockBuilder(client, uri.getDatabase, "uk.gov.hmrc.exports.mongock.changesets")
+  val runner: Mongock = new MongockBuilder(client, uri.getDatabase, "uk.gov.hmrc.exports.mongock.changesets")
     .setLockConfig(lockAcquiredForMinutes, maxWaitingForLockMinutes, maxTries)
     .build()
 

--- a/app/uk/gov/hmrc/exports/mongock/changesets/CacheChangeLog.scala
+++ b/app/uk/gov/hmrc/exports/mongock/changesets/CacheChangeLog.scala
@@ -35,7 +35,11 @@ class CacheChangeLog {
     logger.info("Applying 'CEDS-2250 Add one structure level to /transport/borderModeOfTransportCode'...")
 
     getDeclarationsCollection(db).updateMany(
-      and(exists("transport.borderModeOfTransportCode"), not(Filters.eq("transport.borderModeOfTransportCode", ""))),
+      and(
+        exists("transport.borderModeOfTransportCode"),
+        not(Filters.eq("transport.borderModeOfTransportCode", "")),
+        not(exists("transport.borderModeOfTransportCode.code"))
+      ),
       rename("transport.borderModeOfTransportCode", "temp")
     )
     getDeclarationsCollection(db).updateMany(exists("temp"), rename("temp", "transport.borderModeOfTransportCode.code"))

--- a/app/uk/gov/hmrc/exports/mongock/changesets/JavaCacheChangeLog.java
+++ b/app/uk/gov/hmrc/exports/mongock/changesets/JavaCacheChangeLog.java
@@ -55,7 +55,7 @@ public class JavaCacheChangeLog {
                         exists("locations.goodsLocation.country"),
                         type("locations.goodsLocation.country", "string"),
                         ne("locations.goodsLocation.country", ""),
-                        regex("locations.goodsLocation.country","^.{3,}$" )))
+                        regex("locations.goodsLocation.country", "^.{3,}$")))
                 .forEach((Consumer<Document>) document -> {
                     // Retrieve indexes
                     String documentId = (String) document.get(INDEX_ID);
@@ -110,7 +110,7 @@ public class JavaCacheChangeLog {
 
     @ChangeSet(order = "004", id = "CEDS-2247 Change destination country structure", author = "Patryk Rudnicki")
     public void changeDestinationCountryStructure(MongoDatabase db) {
-        LOGGER.info("Applying 'CEDS-2247 Change destination country structure' db migrations... ");
+        LOGGER.info("Applying 'CEDS-2247 Change destination country structure' db migration... ");
         getCollection(db)
                 .find(and(
                         exists("locations.destinationCountry"),
@@ -141,13 +141,13 @@ public class JavaCacheChangeLog {
 
     @ChangeSet(order = "005", id = "CEDS-2247 Change routing countries structure", author = "Patryk Rudnicki")
     public void changeRoutingCountriesStructure(MongoDatabase db) {
-        LOGGER.info("Applying 'CEDS-2247 Change routing countries structure... ");
+        LOGGER.info("Applying 'CEDS-2247 Change routing countries structure' db migration... ");
         getCollection(db)
                 .find(and(
                         not(elemMatch("locations.routingCountries", exists("code", true))),
                         exists("locations.routingCountries"),
-                        type("locations.routingCountries", "array"),
-                        not(size("locations.routingCountries", 0))))
+                        not(size("locations.routingCountries", 0))
+                ))
                 .forEach((Consumer<Document>) document -> {
                     // Retrieve indexes
                     String documentId = (String) document.get(INDEX_ID);

--- a/test/it/uk/gov/hmrc/exports/mongock/changesets/CacheChangeLogSpec.scala
+++ b/test/it/uk/gov/hmrc/exports/mongock/changesets/CacheChangeLogSpec.scala
@@ -1,0 +1,1239 @@
+package uk.gov.hmrc.exports.mongock.changesets
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.mongodb.client.{MongoCollection, MongoDatabase}
+import com.mongodb.{MongoClient, MongoClientURI}
+import org.bson.Document
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import stubs.TestMongoDB
+import stubs.TestMongoDB.mongoConfiguration
+import uk.gov.hmrc.exports.mongock.changesets.CacheChangeLogSpec._
+
+class CacheChangeLogSpec extends WordSpec with MustMatchers with GuiceOneServerPerSuite with BeforeAndAfterEach {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[com.kenshoo.play.metrics.PlayModule]
+      .configure(mongoConfiguration)
+      .build()
+
+  private val MongoURI = mongoConfiguration.get[String]("mongodb.uri")
+  private val DatabaseName = TestMongoDB.DatabaseName
+  private val CollectionName = "declarations"
+
+  private implicit val mongoDatabase: MongoDatabase = {
+    val uri = new MongoClientURI(MongoURI.replaceAllLiterally("sslEnabled", "ssl"))
+    val client = new MongoClient(uri)
+
+    client.getDatabase(DatabaseName)
+  }
+
+  private val javaChangeLog = new JavaCacheChangeLog()
+  private val changeLog = new CacheChangeLog()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    mongoDatabase.getCollection(CollectionName).drop()
+  }
+
+  override def afterEach(): Unit = {
+    mongoDatabase.getCollection(CollectionName).drop()
+    super.afterEach()
+  }
+
+  private def getDeclarationsCollection(db: MongoDatabase): MongoCollection[Document] = mongoDatabase.getCollection(CollectionName)
+
+  "CacheChangeLog" should {
+
+    "correctly migrate data" when {
+
+      "running ChangeSet no. 001" in {
+
+        runTest(testDataBeforeChangeSet_1, testDataAfterChangeSet_1)(javaChangeLog.dbBaseline)
+      }
+
+      "running ChangeSet no. 002" in {
+
+        runTest(testDataBeforeChangeSet_2, testDataAfterChangeSet_2)(javaChangeLog.updateAllCountriesNameToCodesForLocationPage)
+      }
+
+      "running ChangeSet no. 003" in {
+
+        runTest(testDataBeforeChangeSet_3, testDataAfterChangeSet_3)(javaChangeLog.changeOriginationCountryStructure)
+      }
+
+      "running ChangeSet no. 004" in {
+
+        runTest(testDataBeforeChangeSet_4, testDataAfterChangeSet_4)(javaChangeLog.changeDestinationCountryStructure)
+      }
+
+      "running ChangeSet no. 005" in {
+
+        runTest(testDataBeforeChangeSet_5, testDataAfterChangeSet_5)(javaChangeLog.changeRoutingCountriesStructure)
+      }
+
+      "running ChangeSet no. 006" in {
+
+        runTest(testDataBeforeChangeSet_6, testDataAfterChangeSet_6)(changeLog.updateTransportBorderModeOfTransportCode)
+      }
+    }
+
+    "not change data already migrated" when {
+
+      "running ChangeSet no. 001" in {
+
+        runTest(testDataAfterChangeSet_1, testDataAfterChangeSet_1)(javaChangeLog.dbBaseline)
+      }
+
+      "running ChangeSet no. 002" in {
+
+        runTest(testDataAfterChangeSet_2, testDataAfterChangeSet_2)(javaChangeLog.updateAllCountriesNameToCodesForLocationPage)
+      }
+
+      "running ChangeSet no. 003" in {
+
+        runTest(testDataAfterChangeSet_3, testDataAfterChangeSet_3)(javaChangeLog.changeOriginationCountryStructure)
+      }
+
+      "running ChangeSet no. 004" in {
+
+        runTest(testDataAfterChangeSet_4, testDataAfterChangeSet_4)(javaChangeLog.changeDestinationCountryStructure)
+      }
+
+      "running ChangeSet no. 005" in {
+
+        runTest(testDataAfterChangeSet_5, testDataAfterChangeSet_5)(javaChangeLog.changeRoutingCountriesStructure)
+      }
+
+      "running ChangeSet no. 006" in {
+
+        runTest(testDataAfterChangeSet_6, testDataAfterChangeSet_6)(changeLog.updateTransportBorderModeOfTransportCode)
+      }
+    }
+  }
+
+  private def runTest(inputDataJson: String, expectedDataJson: String)(test: MongoDatabase => Unit)(implicit mongoDatabase: MongoDatabase): Unit = {
+    getDeclarationsCollection(mongoDatabase).insertOne(Document.parse(inputDataJson))
+
+    test(mongoDatabase)
+
+    val result: Document = getDeclarationsCollection(mongoDatabase).find().first()
+    val expectedResult: String = expectedDataJson
+
+    compareJson(result.toJson, expectedResult)
+  }
+
+  private def compareJson(actual: String, expected: String): Unit = {
+    val mapper = new ObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+
+    val jsonMap1 = mapper.readValue(actual, classOf[Map[String, Any]])
+    val jsonMap2 = mapper.readValue(expected, classOf[Map[String, Any]])
+
+    jsonMap1.size mustBe jsonMap2.size
+    jsonMap2.foreach(jsonMap1 must contain(_))
+  }
+
+}
+
+object CacheChangeLogSpec {
+
+  val testDataBeforeChangeSet_1: String = """{
+      |    "_id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |    "id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |    "eori": "GB21885355487467",
+      |    "status": "COMPLETE",
+      |    "createdDateTime": {
+      |        "$date": 1585653005745
+      |    },
+      |    "updatedDateTime": {
+      |        "$date": 1585653072661
+      |    },
+      |    "type": "STANDARD",
+      |    "dispatchLocation": {
+      |        "dispatchLocation": "EX"
+      |    },
+      |    "additionalDeclarationType": "D",
+      |    "consignmentReferences": {
+      |        "ducr": {
+      |            "ducr": "8GB123456486556-101SHIP1"
+      |        },
+      |        "lrn": "QSLRN5914100"
+      |    },
+      |    "transport": {
+      |        "transportPayment": {
+      |            "paymentMethod": "H"
+      |        },
+      |        "containers": [
+      |            {
+      |                "id": "123456",
+      |                "seals": []
+      |            }
+      |        ],
+      |        "borderModeOfTransportCode": "1",
+      |        "meansOfTransportOnDepartureType": "11",
+      |        "meansOfTransportOnDepartureIDNumber": "123456754323356",
+      |        "meansOfTransportCrossingTheBorderNationality": "United Kingdom",
+      |        "meansOfTransportCrossingTheBorderType": "11",
+      |        "meansOfTransportCrossingTheBorderIDNumber": "Superfast Hawk Millenium"
+      |    },
+      |    "parties": {
+      |        "exporterDetails": {
+      |            "details": {
+      |                "eori": "GB717572504502801"
+      |            }
+      |        },
+      |        "consigneeDetails": {
+      |            "details": {
+      |                "address": {
+      |                    "fullName": "Bags Export",
+      |                    "addressLine": "1 Bags Avenue",
+      |                    "townOrCity": "New York",
+      |                    "postCode": "10001",
+      |                    "country": "United States of America"
+      |                }
+      |            }
+      |        },
+      |        "declarantDetails": {
+      |            "details": {
+      |                "eori": "GB717572504502811"
+      |            }
+      |        },
+      |        "representativeDetails": {},
+      |        "declarationAdditionalActorsData": {
+      |            "actors": []
+      |        },
+      |        "declarationHoldersData": {
+      |            "holders": [
+      |                {
+      |                    "authorisationTypeCode": "AEOC",
+      |                    "eori": "GB717572504502811"
+      |                }
+      |            ]
+      |        },
+      |        "carrierDetails": {
+      |            "details": {
+      |                "address": {
+      |                    "fullName": "XYZ Carrier",
+      |                    "addressLine": "School Road",
+      |                    "townOrCity": "London",
+      |                    "postCode": "WS1 2AB",
+      |                    "country": "United Kingdom"
+      |                }
+      |            }
+      |        }
+      |    },
+      |    "locations": {
+      |        "originationCountry": "AF",
+      |        "destinationCountry": "AL",
+      |        "hasRoutingCountries": true,
+      |        "routingCountries": [
+      |            "DZ", "AL"
+      |        ],
+      |        "goodsLocation": {
+      |            "country": "Afghanistan",
+      |            "typeOfLocation": "A",
+      |            "qualifierOfIdentification": "U",
+      |            "identificationOfLocation": "FXTFXTFXT",
+      |            "additionalIdentifier": "123"
+      |        },
+      |        "officeOfExit": {
+      |            "officeId": "GB000434",
+      |            "circumstancesCode": "No"
+      |        },
+      |        "supervisingCustomsOffice": {
+      |            "supervisingCustomsOffice": "GBLBA001"
+      |        },
+      |        "warehouseIdentification": {},
+      |        "inlandModeOfTransportCode": {
+      |            "inlandModeOfTransportCode": "1"
+      |        }
+      |    },
+      |    "items": [
+      |        {
+      |            "id": "8af3g619",
+      |            "sequenceId": 1,
+      |            "procedureCodes": {
+      |                "procedureCode": "1040",
+      |                "additionalProcedureCodes": [
+      |                    "000"
+      |                ]
+      |            },
+      |            "fiscalInformation": {
+      |                "onwardSupplyRelief": "No"
+      |            },
+      |            "statisticalValue": {
+      |                "statisticalValue": "1000"
+      |            },
+      |            "commodityDetails": {
+      |                "combinedNomenclatureCode": "46021910",
+      |                "descriptionOfGoods": "Straw for bottles"
+      |            },
+      |            "dangerousGoodsCode": {},
+      |            "cusCode": {},
+      |            "taricCodes": [],
+      |            "nactCodes": [],
+      |            "packageInformation": [
+      |                {
+      |                    "typesOfPackages": "PK",
+      |                    "numberOfPackages": 10,
+      |                    "shippingMarks": "Shipping description"
+      |                }
+      |            ],
+      |            "commodityMeasure": {
+      |                "supplementaryUnits": "10",
+      |                "netMass": "500",
+      |                "grossMass": "700"
+      |            },
+      |            "additionalInformation": {
+      |                "items": [
+      |                    {
+      |                        "code": "00400",
+      |                        "description": "EXPORTER"
+      |                    }
+      |                ]
+      |            },
+      |            "documentsProducedData": {
+      |                "documents": [
+      |                    {
+      |                        "documentTypeCode": "C501",
+      |                        "documentIdentifier": "GBAEOC717572504502811"
+      |                    }
+      |                ]
+      |            }
+      |        }
+      |    ],
+      |    "totalNumberOfItems": {
+      |        "totalAmountInvoiced": "56764",
+      |        "exchangeRate": "1.49",
+      |        "totalPackage": "1"
+      |    },
+      |    "previousDocuments": {
+      |        "documents": []
+      |    },
+      |    "natureOfTransaction": {
+      |        "natureType": "1"
+      |    }
+      |}
+      |""".stripMargin
+  val testDataAfterChangeSet_1: String = testDataBeforeChangeSet_1
+
+  val testDataBeforeChangeSet_2: String = testDataAfterChangeSet_1
+  val testDataAfterChangeSet_2: String = """{
+      |  "_id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "eori": "GB21885355487467",
+      |  "status": "COMPLETE",
+      |  "createdDateTime": {
+      |    "$date": 1585653005745
+      |  },
+      |  "updatedDateTime": {
+      |    "$date": 1585653072661
+      |  },
+      |  "type": "STANDARD",
+      |  "dispatchLocation": {
+      |    "dispatchLocation": "EX"
+      |  },
+      |  "additionalDeclarationType": "D",
+      |  "consignmentReferences": {
+      |    "ducr": {
+      |      "ducr": "8GB123456486556-101SHIP1"
+      |    },
+      |    "lrn": "QSLRN5914100"
+      |  },
+      |  "transport": {
+      |    "transportPayment": {
+      |      "paymentMethod": "H"
+      |    },
+      |    "containers": [
+      |      {
+      |        "id": "123456",
+      |        "seals": []
+      |      }
+      |    ],
+      |    "borderModeOfTransportCode": "1",
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "123456754323356",
+      |    "meansOfTransportCrossingTheBorderNationality": "United Kingdom",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "Superfast Hawk Millenium"
+      |  },
+      |  "parties": {
+      |    "exporterDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502801"
+      |      }
+      |    },
+      |    "consigneeDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "Bags Export",
+      |          "addressLine": "1 Bags Avenue",
+      |          "townOrCity": "New York",
+      |          "postCode": "10001",
+      |          "country": "United States of America"
+      |        }
+      |      }
+      |    },
+      |    "declarantDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502811"
+      |      }
+      |    },
+      |    "representativeDetails": {},
+      |    "declarationAdditionalActorsData": {
+      |      "actors": []
+      |    },
+      |    "declarationHoldersData": {
+      |      "holders": [
+      |        {
+      |          "authorisationTypeCode": "AEOC",
+      |          "eori": "GB717572504502811"
+      |        }
+      |      ]
+      |    },
+      |    "carrierDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "XYZ Carrier",
+      |          "addressLine": "School Road",
+      |          "townOrCity": "London",
+      |          "postCode": "WS1 2AB",
+      |          "country": "United Kingdom"
+      |        }
+      |      }
+      |    }
+      |  },
+      |  "locations": {
+      |    "originationCountry": "AF",
+      |    "destinationCountry": "AL",
+      |    "hasRoutingCountries": true,
+      |    "routingCountries": [
+      |      "DZ", "AL"
+      |    ],
+      |    "goodsLocation": {
+      |      "country": "AF",
+      |      "typeOfLocation": "A",
+      |      "qualifierOfIdentification": "U",
+      |      "identificationOfLocation": "FXTFXTFXT",
+      |      "additionalIdentifier": "123"
+      |    },
+      |    "officeOfExit": {
+      |      "officeId": "GB000434",
+      |      "circumstancesCode": "No"
+      |    },
+      |    "supervisingCustomsOffice": {
+      |      "supervisingCustomsOffice": "GBLBA001"
+      |    },
+      |    "warehouseIdentification": {},
+      |    "inlandModeOfTransportCode": {
+      |      "inlandModeOfTransportCode": "1"
+      |    }
+      |  },
+      |  "items": [
+      |    {
+      |      "id": "8af3g619",
+      |      "sequenceId": 1,
+      |      "procedureCodes": {
+      |        "procedureCode": "1040",
+      |        "additionalProcedureCodes": [
+      |          "000"
+      |        ]
+      |      },
+      |      "fiscalInformation": {
+      |        "onwardSupplyRelief": "No"
+      |      },
+      |      "statisticalValue": {
+      |        "statisticalValue": "1000"
+      |      },
+      |      "commodityDetails": {
+      |        "combinedNomenclatureCode": "46021910",
+      |        "descriptionOfGoods": "Straw for bottles"
+      |      },
+      |      "dangerousGoodsCode": {},
+      |      "cusCode": {},
+      |      "taricCodes": [],
+      |      "nactCodes": [],
+      |      "packageInformation": [
+      |        {
+      |          "typesOfPackages": "PK",
+      |          "numberOfPackages": 10,
+      |          "shippingMarks": "Shipping description"
+      |        }
+      |      ],
+      |      "commodityMeasure": {
+      |        "supplementaryUnits": "10",
+      |        "netMass": "500",
+      |        "grossMass": "700"
+      |      },
+      |      "additionalInformation": {
+      |        "items": [
+      |          {
+      |            "code": "00400",
+      |            "description": "EXPORTER"
+      |          }
+      |        ]
+      |      },
+      |      "documentsProducedData": {
+      |        "documents": [
+      |          {
+      |            "documentTypeCode": "C501",
+      |            "documentIdentifier": "GBAEOC717572504502811"
+      |          }
+      |        ]
+      |      }
+      |    }
+      |  ],
+      |  "totalNumberOfItems": {
+      |    "totalAmountInvoiced": "56764",
+      |    "exchangeRate": "1.49",
+      |    "totalPackage": "1"
+      |  },
+      |  "previousDocuments": {
+      |    "documents": []
+      |  },
+      |  "natureOfTransaction": {
+      |    "natureType": "1"
+      |  }
+      |}
+      |""".stripMargin
+
+  val testDataBeforeChangeSet_3: String = testDataAfterChangeSet_2
+  val testDataAfterChangeSet_3: String = """{
+      |  "_id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "eori": "GB21885355487467",
+      |  "status": "COMPLETE",
+      |  "createdDateTime": {
+      |    "$date": 1585653005745
+      |  },
+      |  "updatedDateTime": {
+      |    "$date": 1585653072661
+      |  },
+      |  "type": "STANDARD",
+      |  "dispatchLocation": {
+      |    "dispatchLocation": "EX"
+      |  },
+      |  "additionalDeclarationType": "D",
+      |  "consignmentReferences": {
+      |    "ducr": {
+      |      "ducr": "8GB123456486556-101SHIP1"
+      |    },
+      |    "lrn": "QSLRN5914100"
+      |  },
+      |  "transport": {
+      |    "transportPayment": {
+      |      "paymentMethod": "H"
+      |    },
+      |    "containers": [
+      |      {
+      |        "id": "123456",
+      |        "seals": []
+      |      }
+      |    ],
+      |    "borderModeOfTransportCode": "1",
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "123456754323356",
+      |    "meansOfTransportCrossingTheBorderNationality": "United Kingdom",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "Superfast Hawk Millenium"
+      |  },
+      |  "parties": {
+      |    "exporterDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502801"
+      |      }
+      |    },
+      |    "consigneeDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "Bags Export",
+      |          "addressLine": "1 Bags Avenue",
+      |          "townOrCity": "New York",
+      |          "postCode": "10001",
+      |          "country": "United States of America"
+      |        }
+      |      }
+      |    },
+      |    "declarantDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502811"
+      |      }
+      |    },
+      |    "representativeDetails": {},
+      |    "declarationAdditionalActorsData": {
+      |      "actors": []
+      |    },
+      |    "declarationHoldersData": {
+      |      "holders": [
+      |        {
+      |          "authorisationTypeCode": "AEOC",
+      |          "eori": "GB717572504502811"
+      |        }
+      |      ]
+      |    },
+      |    "carrierDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "XYZ Carrier",
+      |          "addressLine": "School Road",
+      |          "townOrCity": "London",
+      |          "postCode": "WS1 2AB",
+      |          "country": "United Kingdom"
+      |        }
+      |      }
+      |    }
+      |  },
+      |  "locations": {
+      |    "destinationCountry": "AL",
+      |    "hasRoutingCountries": true,
+      |    "routingCountries": [
+      |      "DZ",
+      |      "AL"
+      |    ],
+      |    "goodsLocation": {
+      |      "country": "AF",
+      |      "typeOfLocation": "A",
+      |      "qualifierOfIdentification": "U",
+      |      "identificationOfLocation": "FXTFXTFXT",
+      |      "additionalIdentifier": "123"
+      |    },
+      |    "officeOfExit": {
+      |      "officeId": "GB000434",
+      |      "circumstancesCode": "No"
+      |    },
+      |    "supervisingCustomsOffice": {
+      |      "supervisingCustomsOffice": "GBLBA001"
+      |    },
+      |    "warehouseIdentification": {},
+      |    "inlandModeOfTransportCode": {
+      |      "inlandModeOfTransportCode": "1"
+      |    },
+      |    "originationCountry": {
+      |      "code": "AF"
+      |    }
+      |  },
+      |  "items": [
+      |    {
+      |      "id": "8af3g619",
+      |      "sequenceId": 1,
+      |      "procedureCodes": {
+      |        "procedureCode": "1040",
+      |        "additionalProcedureCodes": [
+      |          "000"
+      |        ]
+      |      },
+      |      "fiscalInformation": {
+      |        "onwardSupplyRelief": "No"
+      |      },
+      |      "statisticalValue": {
+      |        "statisticalValue": "1000"
+      |      },
+      |      "commodityDetails": {
+      |        "combinedNomenclatureCode": "46021910",
+      |        "descriptionOfGoods": "Straw for bottles"
+      |      },
+      |      "dangerousGoodsCode": {},
+      |      "cusCode": {},
+      |      "taricCodes": [],
+      |      "nactCodes": [],
+      |      "packageInformation": [
+      |        {
+      |          "typesOfPackages": "PK",
+      |          "numberOfPackages": 10,
+      |          "shippingMarks": "Shipping description"
+      |        }
+      |      ],
+      |      "commodityMeasure": {
+      |        "supplementaryUnits": "10",
+      |        "netMass": "500",
+      |        "grossMass": "700"
+      |      },
+      |      "additionalInformation": {
+      |        "items": [
+      |          {
+      |            "code": "00400",
+      |            "description": "EXPORTER"
+      |          }
+      |        ]
+      |      },
+      |      "documentsProducedData": {
+      |        "documents": [
+      |          {
+      |            "documentTypeCode": "C501",
+      |            "documentIdentifier": "GBAEOC717572504502811"
+      |          }
+      |        ]
+      |      }
+      |    }
+      |  ],
+      |  "totalNumberOfItems": {
+      |    "totalAmountInvoiced": "56764",
+      |    "exchangeRate": "1.49",
+      |    "totalPackage": "1"
+      |  },
+      |  "previousDocuments": {
+      |    "documents": []
+      |  },
+      |  "natureOfTransaction": {
+      |    "natureType": "1"
+      |  }
+      |}""".stripMargin
+
+  val testDataBeforeChangeSet_4: String = testDataAfterChangeSet_3
+  val testDataAfterChangeSet_4: String = """{
+      |  "_id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "eori": "GB21885355487467",
+      |  "status": "COMPLETE",
+      |  "createdDateTime": {
+      |    "$date": 1585653005745
+      |  },
+      |  "updatedDateTime": {
+      |    "$date": 1585653072661
+      |  },
+      |  "type": "STANDARD",
+      |  "dispatchLocation": {
+      |    "dispatchLocation": "EX"
+      |  },
+      |  "additionalDeclarationType": "D",
+      |  "consignmentReferences": {
+      |    "ducr": {
+      |      "ducr": "8GB123456486556-101SHIP1"
+      |    },
+      |    "lrn": "QSLRN5914100"
+      |  },
+      |  "transport": {
+      |    "transportPayment": {
+      |      "paymentMethod": "H"
+      |    },
+      |    "containers": [
+      |      {
+      |        "id": "123456",
+      |        "seals": []
+      |      }
+      |    ],
+      |    "borderModeOfTransportCode": "1",
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "123456754323356",
+      |    "meansOfTransportCrossingTheBorderNationality": "United Kingdom",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "Superfast Hawk Millenium"
+      |  },
+      |  "parties": {
+      |    "exporterDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502801"
+      |      }
+      |    },
+      |    "consigneeDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "Bags Export",
+      |          "addressLine": "1 Bags Avenue",
+      |          "townOrCity": "New York",
+      |          "postCode": "10001",
+      |          "country": "United States of America"
+      |        }
+      |      }
+      |    },
+      |    "declarantDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502811"
+      |      }
+      |    },
+      |    "representativeDetails": {},
+      |    "declarationAdditionalActorsData": {
+      |      "actors": []
+      |    },
+      |    "declarationHoldersData": {
+      |      "holders": [
+      |        {
+      |          "authorisationTypeCode": "AEOC",
+      |          "eori": "GB717572504502811"
+      |        }
+      |      ]
+      |    },
+      |    "carrierDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "XYZ Carrier",
+      |          "addressLine": "School Road",
+      |          "townOrCity": "London",
+      |          "postCode": "WS1 2AB",
+      |          "country": "United Kingdom"
+      |        }
+      |      }
+      |    }
+      |  },
+      |  "locations": {
+      |    "destinationCountry": {
+      |      "code": "AL"
+      |    },
+      |    "hasRoutingCountries": true,
+      |    "routingCountries": [
+      |      "DZ",
+      |      "AL"
+      |    ],
+      |    "goodsLocation": {
+      |      "country": "AF",
+      |      "typeOfLocation": "A",
+      |      "qualifierOfIdentification": "U",
+      |      "identificationOfLocation": "FXTFXTFXT",
+      |      "additionalIdentifier": "123"
+      |    },
+      |    "officeOfExit": {
+      |      "officeId": "GB000434",
+      |      "circumstancesCode": "No"
+      |    },
+      |    "supervisingCustomsOffice": {
+      |      "supervisingCustomsOffice": "GBLBA001"
+      |    },
+      |    "warehouseIdentification": {},
+      |    "inlandModeOfTransportCode": {
+      |      "inlandModeOfTransportCode": "1"
+      |    },
+      |    "originationCountry": {
+      |      "code": "AF"
+      |    }
+      |  },
+      |  "items": [
+      |    {
+      |      "id": "8af3g619",
+      |      "sequenceId": 1,
+      |      "procedureCodes": {
+      |        "procedureCode": "1040",
+      |        "additionalProcedureCodes": [
+      |          "000"
+      |        ]
+      |      },
+      |      "fiscalInformation": {
+      |        "onwardSupplyRelief": "No"
+      |      },
+      |      "statisticalValue": {
+      |        "statisticalValue": "1000"
+      |      },
+      |      "commodityDetails": {
+      |        "combinedNomenclatureCode": "46021910",
+      |        "descriptionOfGoods": "Straw for bottles"
+      |      },
+      |      "dangerousGoodsCode": {},
+      |      "cusCode": {},
+      |      "taricCodes": [],
+      |      "nactCodes": [],
+      |      "packageInformation": [
+      |        {
+      |          "typesOfPackages": "PK",
+      |          "numberOfPackages": 10,
+      |          "shippingMarks": "Shipping description"
+      |        }
+      |      ],
+      |      "commodityMeasure": {
+      |        "supplementaryUnits": "10",
+      |        "netMass": "500",
+      |        "grossMass": "700"
+      |      },
+      |      "additionalInformation": {
+      |        "items": [
+      |          {
+      |            "code": "00400",
+      |            "description": "EXPORTER"
+      |          }
+      |        ]
+      |      },
+      |      "documentsProducedData": {
+      |        "documents": [
+      |          {
+      |            "documentTypeCode": "C501",
+      |            "documentIdentifier": "GBAEOC717572504502811"
+      |          }
+      |        ]
+      |      }
+      |    }
+      |  ],
+      |  "totalNumberOfItems": {
+      |    "totalAmountInvoiced": "56764",
+      |    "exchangeRate": "1.49",
+      |    "totalPackage": "1"
+      |  },
+      |  "previousDocuments": {
+      |    "documents": []
+      |  },
+      |  "natureOfTransaction": {
+      |    "natureType": "1"
+      |  }
+      |}""".stripMargin
+
+  val testDataBeforeChangeSet_5: String = testDataAfterChangeSet_4
+  val testDataAfterChangeSet_5: String = """{
+      |  "_id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "eori": "GB21885355487467",
+      |  "status": "COMPLETE",
+      |  "createdDateTime": {
+      |    "$date": 1585653005745
+      |  },
+      |  "updatedDateTime": {
+      |    "$date": 1585653072661
+      |  },
+      |  "type": "STANDARD",
+      |  "dispatchLocation": {
+      |    "dispatchLocation": "EX"
+      |  },
+      |  "additionalDeclarationType": "D",
+      |  "consignmentReferences": {
+      |    "ducr": {
+      |      "ducr": "8GB123456486556-101SHIP1"
+      |    },
+      |    "lrn": "QSLRN5914100"
+      |  },
+      |  "transport": {
+      |    "transportPayment": {
+      |      "paymentMethod": "H"
+      |    },
+      |    "containers": [
+      |      {
+      |        "id": "123456",
+      |        "seals": []
+      |      }
+      |    ],
+      |    "borderModeOfTransportCode": "1",
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "123456754323356",
+      |    "meansOfTransportCrossingTheBorderNationality": "United Kingdom",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "Superfast Hawk Millenium"
+      |  },
+      |  "parties": {
+      |    "exporterDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502801"
+      |      }
+      |    },
+      |    "consigneeDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "Bags Export",
+      |          "addressLine": "1 Bags Avenue",
+      |          "townOrCity": "New York",
+      |          "postCode": "10001",
+      |          "country": "United States of America"
+      |        }
+      |      }
+      |    },
+      |    "declarantDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502811"
+      |      }
+      |    },
+      |    "representativeDetails": {},
+      |    "declarationAdditionalActorsData": {
+      |      "actors": []
+      |    },
+      |    "declarationHoldersData": {
+      |      "holders": [
+      |        {
+      |          "authorisationTypeCode": "AEOC",
+      |          "eori": "GB717572504502811"
+      |        }
+      |      ]
+      |    },
+      |    "carrierDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "XYZ Carrier",
+      |          "addressLine": "School Road",
+      |          "townOrCity": "London",
+      |          "postCode": "WS1 2AB",
+      |          "country": "United Kingdom"
+      |        }
+      |      }
+      |    }
+      |  },
+      |  "locations": {
+      |    "destinationCountry": {
+      |      "code": "AL"
+      |    },
+      |    "hasRoutingCountries": true,
+      |    "routingCountries": [
+      |      { "code": "DZ" },
+      |      { "code": "AL" }
+      |    ],
+      |    "goodsLocation": {
+      |      "country": "AF",
+      |      "typeOfLocation": "A",
+      |      "qualifierOfIdentification": "U",
+      |      "identificationOfLocation": "FXTFXTFXT",
+      |      "additionalIdentifier": "123"
+      |    },
+      |    "officeOfExit": {
+      |      "officeId": "GB000434",
+      |      "circumstancesCode": "No"
+      |    },
+      |    "supervisingCustomsOffice": {
+      |      "supervisingCustomsOffice": "GBLBA001"
+      |    },
+      |    "warehouseIdentification": {},
+      |    "inlandModeOfTransportCode": {
+      |      "inlandModeOfTransportCode": "1"
+      |    },
+      |    "originationCountry": {
+      |      "code": "AF"
+      |    }
+      |  },
+      |  "items": [
+      |    {
+      |      "id": "8af3g619",
+      |      "sequenceId": 1,
+      |      "procedureCodes": {
+      |        "procedureCode": "1040",
+      |        "additionalProcedureCodes": [
+      |          "000"
+      |        ]
+      |      },
+      |      "fiscalInformation": {
+      |        "onwardSupplyRelief": "No"
+      |      },
+      |      "statisticalValue": {
+      |        "statisticalValue": "1000"
+      |      },
+      |      "commodityDetails": {
+      |        "combinedNomenclatureCode": "46021910",
+      |        "descriptionOfGoods": "Straw for bottles"
+      |      },
+      |      "dangerousGoodsCode": {},
+      |      "cusCode": {},
+      |      "taricCodes": [],
+      |      "nactCodes": [],
+      |      "packageInformation": [
+      |        {
+      |          "typesOfPackages": "PK",
+      |          "numberOfPackages": 10,
+      |          "shippingMarks": "Shipping description"
+      |        }
+      |      ],
+      |      "commodityMeasure": {
+      |        "supplementaryUnits": "10",
+      |        "netMass": "500",
+      |        "grossMass": "700"
+      |      },
+      |      "additionalInformation": {
+      |        "items": [
+      |          {
+      |            "code": "00400",
+      |            "description": "EXPORTER"
+      |          }
+      |        ]
+      |      },
+      |      "documentsProducedData": {
+      |        "documents": [
+      |          {
+      |            "documentTypeCode": "C501",
+      |            "documentIdentifier": "GBAEOC717572504502811"
+      |          }
+      |        ]
+      |      }
+      |    }
+      |  ],
+      |  "totalNumberOfItems": {
+      |    "totalAmountInvoiced": "56764",
+      |    "exchangeRate": "1.49",
+      |    "totalPackage": "1"
+      |  },
+      |  "previousDocuments": {
+      |    "documents": []
+      |  },
+      |  "natureOfTransaction": {
+      |    "natureType": "1"
+      |  }
+      |}""".stripMargin
+
+  val testDataBeforeChangeSet_6: String = testDataAfterChangeSet_5
+  val testDataAfterChangeSet_6: String = """{
+      |  "_id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "id": "3414ac6d-13ba-415c-9ac0-f5ffb3fc2fed",
+      |  "eori": "GB21885355487467",
+      |  "status": "COMPLETE",
+      |  "createdDateTime": {
+      |    "$date": 1585653005745
+      |  },
+      |  "updatedDateTime": {
+      |    "$date": 1585653072661
+      |  },
+      |  "type": "STANDARD",
+      |  "dispatchLocation": {
+      |    "dispatchLocation": "EX"
+      |  },
+      |  "additionalDeclarationType": "D",
+      |  "consignmentReferences": {
+      |    "ducr": {
+      |      "ducr": "8GB123456486556-101SHIP1"
+      |    },
+      |    "lrn": "QSLRN5914100"
+      |  },
+      |  "transport": {
+      |    "transportPayment": {
+      |      "paymentMethod": "H"
+      |    },
+      |    "containers": [
+      |      {
+      |        "id": "123456",
+      |        "seals": []
+      |      }
+      |    ],
+      |    "borderModeOfTransportCode": { "code": "1" },
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "123456754323356",
+      |    "meansOfTransportCrossingTheBorderNationality": "United Kingdom",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "Superfast Hawk Millenium"
+      |  },
+      |  "parties": {
+      |    "exporterDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502801"
+      |      }
+      |    },
+      |    "consigneeDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "Bags Export",
+      |          "addressLine": "1 Bags Avenue",
+      |          "townOrCity": "New York",
+      |          "postCode": "10001",
+      |          "country": "United States of America"
+      |        }
+      |      }
+      |    },
+      |    "declarantDetails": {
+      |      "details": {
+      |        "eori": "GB717572504502811"
+      |      }
+      |    },
+      |    "representativeDetails": {},
+      |    "declarationAdditionalActorsData": {
+      |      "actors": []
+      |    },
+      |    "declarationHoldersData": {
+      |      "holders": [
+      |        {
+      |          "authorisationTypeCode": "AEOC",
+      |          "eori": "GB717572504502811"
+      |        }
+      |      ]
+      |    },
+      |    "carrierDetails": {
+      |      "details": {
+      |        "address": {
+      |          "fullName": "XYZ Carrier",
+      |          "addressLine": "School Road",
+      |          "townOrCity": "London",
+      |          "postCode": "WS1 2AB",
+      |          "country": "United Kingdom"
+      |        }
+      |      }
+      |    }
+      |  },
+      |  "locations": {
+      |    "destinationCountry": {
+      |      "code": "AL"
+      |    },
+      |    "hasRoutingCountries": true,
+      |    "routingCountries": [
+      |      { "code": "DZ" },
+      |      { "code": "AL" }
+      |    ],
+      |    "goodsLocation": {
+      |      "country": "AF",
+      |      "typeOfLocation": "A",
+      |      "qualifierOfIdentification": "U",
+      |      "identificationOfLocation": "FXTFXTFXT",
+      |      "additionalIdentifier": "123"
+      |    },
+      |    "officeOfExit": {
+      |      "officeId": "GB000434",
+      |      "circumstancesCode": "No"
+      |    },
+      |    "supervisingCustomsOffice": {
+      |      "supervisingCustomsOffice": "GBLBA001"
+      |    },
+      |    "warehouseIdentification": {},
+      |    "inlandModeOfTransportCode": {
+      |      "inlandModeOfTransportCode": "1"
+      |    },
+      |    "originationCountry": {
+      |      "code": "AF"
+      |    }
+      |  },
+      |  "items": [
+      |    {
+      |      "id": "8af3g619",
+      |      "sequenceId": 1,
+      |      "procedureCodes": {
+      |        "procedureCode": "1040",
+      |        "additionalProcedureCodes": [
+      |          "000"
+      |        ]
+      |      },
+      |      "fiscalInformation": {
+      |        "onwardSupplyRelief": "No"
+      |      },
+      |      "statisticalValue": {
+      |        "statisticalValue": "1000"
+      |      },
+      |      "commodityDetails": {
+      |        "combinedNomenclatureCode": "46021910",
+      |        "descriptionOfGoods": "Straw for bottles"
+      |      },
+      |      "dangerousGoodsCode": {},
+      |      "cusCode": {},
+      |      "taricCodes": [],
+      |      "nactCodes": [],
+      |      "packageInformation": [
+      |        {
+      |          "typesOfPackages": "PK",
+      |          "numberOfPackages": 10,
+      |          "shippingMarks": "Shipping description"
+      |        }
+      |      ],
+      |      "commodityMeasure": {
+      |        "supplementaryUnits": "10",
+      |        "netMass": "500",
+      |        "grossMass": "700"
+      |      },
+      |      "additionalInformation": {
+      |        "items": [
+      |          {
+      |            "code": "00400",
+      |            "description": "EXPORTER"
+      |          }
+      |        ]
+      |      },
+      |      "documentsProducedData": {
+      |        "documents": [
+      |          {
+      |            "documentTypeCode": "C501",
+      |            "documentIdentifier": "GBAEOC717572504502811"
+      |          }
+      |        ]
+      |      }
+      |    }
+      |  ],
+      |  "totalNumberOfItems": {
+      |    "totalAmountInvoiced": "56764",
+      |    "exchangeRate": "1.49",
+      |    "totalPackage": "1"
+      |  },
+      |  "previousDocuments": {
+      |    "documents": []
+      |  },
+      |  "natureOfTransaction": {
+      |    "natureType": "1"
+      |  }
+      |}""".stripMargin
+
+}

--- a/test/util/stubs/TestMongoDB.scala
+++ b/test/util/stubs/TestMongoDB.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package stubs
+
+import play.api.Configuration
+
+object TestMongoDB {
+
+  val Port = 27017
+  val DatabaseName = "test-customs-declare-exports"
+
+  val mongoConfiguration: Configuration = Configuration.from(Map("mongodb.uri" -> s"mongodb://localhost:$Port/$DatabaseName"))
+}


### PR DESCRIPTION
Except adding tests for migration functions, it also fixes ChangeSets no. 005 and 006.

In the first one the problem was that non-migrated documents were not recognized
correctly and therefore the migration was not applied to them.
The problem turned out to be a `type` parameter in the search query.

In the second one the problem was that the migration could potentially be executed
on documents that were already correctly migrated, adding another level of nesting 
with every call. Additional query parameter was added to prevent such situation.