### PR TITLE
CEDS-2065 - add new 'representing another agent' field to model

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
@@ -43,7 +43,7 @@ object DeclarantDetails {
   implicit val format: OFormat[DeclarantDetails] = Json.format[DeclarantDetails]
 }
 
-case class RepresentativeDetails(details: Option[EntityDetails], statusCode: Option[String])
+case class RepresentativeDetails(details: Option[EntityDetails], statusCode: Option[String], representingOtherAgent: Option[String])
 object RepresentativeDetails {
   implicit val format: OFormat[RepresentativeDetails] = Json.format[RepresentativeDetails]
   val Declarant = "1"

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -155,7 +155,7 @@ trait ExportsDeclarationBuilder {
     withRepresentativeDetails(Some(EntityDetails(eori, address)), statusCode)
 
   def withRepresentativeDetails(details: Option[EntityDetails], statusCode: Option[String]): ExportsDeclarationModifier =
-    cache => cache.copy(parties = cache.parties.copy(representativeDetails = Some(RepresentativeDetails(details, statusCode))))
+    cache => cache.copy(parties = cache.parties.copy(representativeDetails = Some(RepresentativeDetails(details, statusCode, Some("Yes")))))
 
   def withDeclarationAdditionalActors(data: DeclarationAdditionalActor*): ExportsDeclarationModifier =
     cache => cache.copy(parties = cache.parties.copy(declarationAdditionalActorsData = Some(DeclarationAdditionalActors(data))))


### PR DESCRIPTION
Adding new field to RepresentativeDetails.  The field is not used in constructing the XML payload - it is purely there to drive frontend navigation and validation logic.