### PR TITLE
CEDS-2401 - Ask if Declarant is the Exporter

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
@@ -43,6 +43,11 @@ object DeclarantDetails {
   implicit val format: OFormat[DeclarantDetails] = Json.format[DeclarantDetails]
 }
 
+case class DeclarantIsExporter(answer: String)
+object DeclarantIsExporter {
+  implicit val format: OFormat[DeclarantIsExporter] = Json.format[DeclarantIsExporter]
+}
+
 case class RepresentativeDetails(details: Option[EntityDetails], statusCode: Option[String], representingOtherAgent: Option[String])
 object RepresentativeDetails {
   implicit val format: OFormat[RepresentativeDetails] = Json.format[RepresentativeDetails]
@@ -80,6 +85,7 @@ case class Parties(
   exporterDetails: Option[ExporterDetails] = None,
   consigneeDetails: Option[ConsigneeDetails] = None,
   declarantDetails: Option[DeclarantDetails] = None,
+  declarantIsExporter: Option[DeclarantIsExporter] = None,
   representativeDetails: Option[RepresentativeDetails] = None,
   declarationAdditionalActorsData: Option[DeclarationAdditionalActors] = None,
   declarationHoldersData: Option[DeclarationHolders] = None,

--- a/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
@@ -43,7 +43,9 @@ object DeclarantDetails {
   implicit val format: OFormat[DeclarantDetails] = Json.format[DeclarantDetails]
 }
 
-case class DeclarantIsExporter(answer: String)
+case class DeclarantIsExporter(answer: String) {
+  def isExporter: Boolean = answer == "Yes"
+}
 object DeclarantIsExporter {
   implicit val format: OFormat[DeclarantIsExporter] = Json.format[DeclarantIsExporter]
 }

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExporterBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/ExporterBuilderSpec.scala
@@ -17,13 +17,13 @@
 package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import testdata.ExportsDeclarationBuilder
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.Address
 import uk.gov.hmrc.exports.services.CountriesService
 import uk.gov.hmrc.exports.services.mapping.declaration.ExporterBuilder
-import testdata.ExportsDeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
 
 class ExporterBuilderSpec extends WordSpec with Matchers with MockitoSugar with ExportsDeclarationBuilder {
@@ -81,6 +81,40 @@ class ExporterBuilderSpec extends WordSpec with Matchers with MockitoSugar with 
         declaration.getExporter.getID.getValue should be("eori")
         declaration.getExporter.getName should be(null)
         declaration.getExporter.getAddress should be(null)
+      }
+
+      "declarant is exporter and exporter details not provided" in {
+        val model =
+          aDeclaration(withoutExporterDetails(), withDeclarantDetails(eori = Some("dec_eori")), withDeclarantIsExporter())
+        val declaration = new Declaration()
+
+        builder.buildThenAdd(model, declaration)
+
+        declaration.getExporter.getID.getValue should be("dec_eori")
+      }
+
+      "declarant is exporter and exporter details are ignored" in {
+        val model =
+          aDeclaration(withExporterDetails(eori = Some("exporter_eori")), withDeclarantDetails(eori = Some("dec_eori")), withDeclarantIsExporter())
+        val declaration = new Declaration()
+
+        builder.buildThenAdd(model, declaration)
+
+        declaration.getExporter.getID.getValue should be("dec_eori")
+      }
+
+      "declarant is not exporter and exporter details used" in {
+        val model =
+          aDeclaration(
+            withExporterDetails(eori = Some("exporter_eori")),
+            withDeclarantDetails(eori = Some("dec_eori")),
+            withDeclarantIsExporter("No")
+          )
+        val declaration = new Declaration()
+
+        builder.buildThenAdd(model, declaration)
+
+        declaration.getExporter.getID.getValue should be("exporter_eori")
       }
     }
   }

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -148,6 +148,9 @@ trait ExportsDeclarationBuilder {
   def withDeclarantDetails(eori: Option[String] = None, address: Option[Address] = None): ExportsDeclarationModifier =
     cache => cache.copy(parties = cache.parties.copy(declarantDetails = Some(DeclarantDetails(EntityDetails(eori, address)))))
 
+  def withDeclarantIsExporter(answer: String = "Yes"): ExportsDeclarationModifier =
+    cache => cache.copy(parties = cache.parties.copy(declarantIsExporter = Some(DeclarantIsExporter(answer))))
+
   def withoutRepresentativeDetails(): ExportsDeclarationModifier =
     cache => cache.copy(parties = cache.parties.copy(representativeDetails = None))
 


### PR DESCRIPTION
These changes introduce a new section to the `Parties` to store the answer to "is the declarant the exporter".
If the answer is "Yes" then the declarant's EORI is used in the ExporterBuilder.

These changes are a dependancy for the FE changes to come, but are backward compatible with existing FE and so can be merged in independently. 