### PR TITLE
CEDS-2065-rework - change to logic for AgentBuilder

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/Parties.scala
@@ -50,7 +50,9 @@ object DeclarantIsExporter {
   implicit val format: OFormat[DeclarantIsExporter] = Json.format[DeclarantIsExporter]
 }
 
-case class RepresentativeDetails(details: Option[EntityDetails], statusCode: Option[String], representingOtherAgent: Option[String])
+case class RepresentativeDetails(details: Option[EntityDetails], statusCode: Option[String], representingOtherAgent: Option[String]) {
+  def isRepresentingOtherAgent = representingOtherAgent.contains("Yes")
+}
 object RepresentativeDetails {
   implicit val format: OFormat[RepresentativeDetails] = Json.format[RepresentativeDetails]
   val Declarant = "1"

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/AgentBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/AgentBuilderSpec.scala
@@ -17,13 +17,13 @@
 package unit.uk.gov.hmrc.exports.services.mapping.declaration
 
 import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
+import org.scalatestplus.mockito.MockitoSugar
+import testdata.ExportsDeclarationBuilder
 import uk.gov.hmrc.exports.models.Country
 import uk.gov.hmrc.exports.models.declaration.{Address, EntityDetails, RepresentativeDetails}
 import uk.gov.hmrc.exports.services.CountriesService
 import uk.gov.hmrc.exports.services.mapping.declaration.AgentBuilder
-import testdata.ExportsDeclarationBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
 
 class AgentBuilderSpec extends WordSpec with Matchers with MockitoSugar with ExportsDeclarationBuilder {
@@ -121,6 +121,28 @@ class AgentBuilderSpec extends WordSpec with Matchers with MockitoSugar with Exp
         agent.getName should be(null)
         agent.getAddress should be(null)
         agent.getFunctionCode.getValue should be("2")
+      }
+      "declarant not representing another agent" in {
+        val model =
+          aDeclaration(
+            withRepresentativeDetails(
+              details = None,
+              statusCode = Some(RepresentativeDetails.DirectRepresentative),
+              representingAnotherAgent = Some("No")
+            ),
+            withDeclarantDetails(eori = Some("DEC_EORI"))
+          )
+
+        val agentBuilder = new AgentBuilder(mockCountriesService)
+        val emptyDeclaration = new Declaration
+
+        agentBuilder.buildThenAdd(model, emptyDeclaration)
+        val agent: Declaration.Agent = emptyDeclaration.getAgent
+
+        agent.getID.getValue should be("DEC_EORI")
+        agent.getName should be(null)
+        agent.getAddress should be(null)
+        agent.getFunctionCode.getValue should be(RepresentativeDetails.DirectRepresentative)
       }
     }
   }

--- a/test/util/stubs/SeedMongo.scala
+++ b/test/util/stubs/SeedMongo.scala
@@ -42,7 +42,7 @@ object SeedMongo extends App with ExportsDeclarationBuilder with ExportsItemBuil
     withExporterDetails(Some("GB717572504502801")),
     withConsigneeDetails(None, Some(Address("Bags Export", "1 Bags Avenue", "New York", "NA", "United States of America"))),
     withDeclarantDetails(Some("GB717572504502811")),
-    withRepresentativeDetails(Some("GB717572504502809"), None, Some("3")),
+    withRepresentativeDetails(Some(EntityDetails(Some("GB717572504502809"), None)), Some("3")),
     withDeclarationHolders(DeclarationHolder(Some("AEOC"), Some("GB717572504502811"))),
     withCarrierDetails(None, Some(Address("XYZ Carrier", "School Road", "London", "WS1 2AB", "United Kingdom"))),
     withOriginationCountry(),

--- a/test/util/testdata/ExportsDeclarationBuilder.scala
+++ b/test/util/testdata/ExportsDeclarationBuilder.scala
@@ -154,11 +154,13 @@ trait ExportsDeclarationBuilder {
   def withoutRepresentativeDetails(): ExportsDeclarationModifier =
     cache => cache.copy(parties = cache.parties.copy(representativeDetails = None))
 
-  def withRepresentativeDetails(eori: Option[String], address: Option[Address], statusCode: Option[String]): ExportsDeclarationModifier =
-    withRepresentativeDetails(Some(EntityDetails(eori, address)), statusCode)
-
-  def withRepresentativeDetails(details: Option[EntityDetails], statusCode: Option[String]): ExportsDeclarationModifier =
-    cache => cache.copy(parties = cache.parties.copy(representativeDetails = Some(RepresentativeDetails(details, statusCode, Some("Yes")))))
+  def withRepresentativeDetails(
+    details: Option[EntityDetails],
+    statusCode: Option[String],
+    representingAnotherAgent: Option[String] = Some("Yes")
+  ): ExportsDeclarationModifier =
+    cache =>
+      cache.copy(parties = cache.parties.copy(representativeDetails = Some(RepresentativeDetails(details, statusCode, representingAnotherAgent))))
 
   def withDeclarationAdditionalActors(data: DeclarationAdditionalActor*): ExportsDeclarationModifier =
     cache => cache.copy(parties = cache.parties.copy(declarationAdditionalActorsData = Some(DeclarationAdditionalActors(data))))


### PR DESCRIPTION
If the user is representing another agent we build the Agent from the representative EORI and the representative status.  Otherwise, we use the declarants EORI and the representative status.