### PR TITLE
CEDS-2298 Display Time always on British time zone

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
@@ -16,20 +16,36 @@
 
 package uk.gov.hmrc.exports.models.declaration.notifications
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.functional.syntax._
+import play.api.libs.json.{Json, Reads, _}
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.SubmissionStatus
 
 case class Notification(
   actionId: String,
   mrn: String,
-  dateTimeIssued: LocalDateTime,
+  dateTimeIssued: ZonedDateTime,
   status: SubmissionStatus,
   errors: Seq[NotificationError],
   payload: String
 )
 
 object Notification {
-  implicit val format: OFormat[Notification] = Json.format[Notification]
+  implicit val readLocalDateTimeFromString: Reads[ZonedDateTime] = implicitly[Reads[LocalDateTime]]
+    .map(ZonedDateTime.of(_, ZoneId.of("UTC")))
+
+  implicit val writes: OWrites[Notification] = Json.writes[Notification]
+  implicit val reads: Reads[Notification] =
+    ((__ \ "actionId").read[String] and
+      (__ \ "mrn").read[String] and
+      ((__ \ "dateTimeIssued").read[ZonedDateTime] or (__ \ "dateTimeIssued").read[ZonedDateTime](readLocalDateTimeFromString)) and
+      (__ \ "status").read[SubmissionStatus] and
+      (__ \ "errors").read[Seq[NotificationError]] and
+      (__ \ "payload").read[String])(Notification.apply _)
+
+  implicit val notificationsReads: Reads[Seq[Notification]] = Reads.seq(reads)
+  implicit val notificationsWrites: Writes[Seq[Notification]] = Writes.seq(writes)
+
+  implicit val format: Format[Notification] = Format(reads, writes)
 }

--- a/app/uk/gov/hmrc/exports/services/NotificationService.scala
+++ b/app/uk/gov/hmrc/exports/services/NotificationService.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.exports.services
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 import java.time.format.DateTimeFormatter
 
 import javax.inject.{Inject, Singleton}
@@ -106,7 +106,7 @@ class NotificationService @Inject()(submissionRepository: SubmissionRepository, 
         val mrn = (singleResponseXml \ "Declaration" \ "ID").text
         val formatter304 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
         val dateTimeIssued =
-          LocalDateTime.parse((singleResponseXml \ "IssueDateTime" \ "DateTimeString").text, formatter304)
+          ZonedDateTime.of(LocalDateTime.parse((singleResponseXml \ "IssueDateTime" \ "DateTimeString").text, formatter304), ZoneId.of("UTC"))
         val functionCode = (singleResponseXml \ "FunctionCode").text
 
         val nameCode =

--- a/test/unit/uk/gov/hmrc/exports/controllers/NotificationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/NotificationControllerSpec.scala
@@ -32,7 +32,6 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.{AuthConnector, InsufficientEnrolments}
-import uk.gov.hmrc.exports.metrics.ExportsMetrics
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.services.{NotificationService, SubmissionService}
 import uk.gov.hmrc.wco.dec.{DateTimeString, Response, ResponseDateTimeElement}

--- a/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/NotificationServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services
 
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import org.mockito.Mockito.{times, verify, verifyZeroInteractions, when}
@@ -28,16 +28,16 @@ import org.scalatest.{MustMatchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
 import reactivemongo.bson.{BSONDocument, BSONInteger, BSONString}
 import reactivemongo.core.errors.DetailedDatabaseException
-import uk.gov.hmrc.exports.models.{Pointer, PointerSection}
-import uk.gov.hmrc.exports.models.PointerSectionType.{FIELD, SEQUENCE}
-import uk.gov.hmrc.exports.models.declaration.notifications.Notification
-import uk.gov.hmrc.exports.models.declaration.submissions.{Action, Submission, SubmissionRequest, SubmissionStatus}
-import uk.gov.hmrc.exports.repositories.{NotificationRepository, SubmissionRepository}
-import uk.gov.hmrc.exports.services.{NotificationService, WCOPointerMappingService}
-import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder._
 import testdata.ExportsTestData._
 import testdata.NotificationTestData._
 import testdata.SubmissionTestData._
+import uk.gov.hmrc.exports.models.PointerSectionType.{FIELD, SEQUENCE}
+import uk.gov.hmrc.exports.models.declaration.notifications.Notification
+import uk.gov.hmrc.exports.models.declaration.submissions.{Action, Submission, SubmissionRequest, SubmissionStatus}
+import uk.gov.hmrc.exports.models.{Pointer, PointerSection}
+import uk.gov.hmrc.exports.repositories.{NotificationRepository, SubmissionRepository}
+import uk.gov.hmrc.exports.services.NotificationService
+import unit.uk.gov.hmrc.exports.base.UnitTestMockBuilder._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -135,7 +135,8 @@ class NotificationServiceSpec extends WordSpec with MockitoSugar with ScalaFutur
 
   "Get Notifications" should {
     val submission = Submission("id", "eori", "lrn", Some("mrn"), "ducr", Seq(Action("id1", SubmissionRequest)))
-    val notifications = Seq(Notification("id1", "mrn", LocalDateTime.now(), SubmissionStatus.ACCEPTED, Seq.empty, ""))
+    val notifications =
+      Seq(Notification("id1", "mrn", ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("UTC")), SubmissionStatus.ACCEPTED, Seq.empty, ""))
 
     "retrieve by conversation IDs" in new Test {
       when(notificationRepositoryMock.findNotificationsByActionIds(any[Seq[String]]))

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.exports.services
 
-import java.time.LocalDateTime
+import java.time.{Instant, LocalDateTime, ZoneOffset, ZonedDateTime}
 
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, anyString, eq => meq}
@@ -24,22 +24,20 @@ import org.mockito.Mockito._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
+import testdata.ExportsDeclarationBuilder
+import testdata.ExportsTestData._
+import testdata.SubmissionTestData._
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.models.declaration.submissions._
 import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration}
-import uk.gov.hmrc.exports.models.{LocalReferenceNumber, SubmissionRequestHeaders}
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.services.mapping.CancellationMetaDataBuilder
 import uk.gov.hmrc.exports.services.{SubmissionService, WcoMapperService}
 import uk.gov.hmrc.http.HeaderCarrier
-import testdata.ExportsDeclarationBuilder
-import testdata.ExportsTestData._
-import testdata.SubmissionTestData._
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.xml.NodeSeq
 
 class SubmissionServiceSpec
     extends WordSpec with MockitoSugar with ScalaFutures with MustMatchers with ExportsDeclarationBuilder with Eventually with BeforeAndAfterEach {
@@ -126,7 +124,7 @@ class SubmissionServiceSpec
 
     "submit to the Dec API" when {
       val declaration = aDeclaration()
-      val notification = Notification("id", "mrn", LocalDateTime.now(), SubmissionStatus.ACCEPTED, Seq.empty, "xml")
+      val notification = Notification("id", "mrn", ZonedDateTime.of(LocalDateTime.now(), ZoneOffset.UTC), SubmissionStatus.ACCEPTED, Seq.empty, "xml")
       val submission = Submission(declaration, "lrn", "mrn")
 
       "valid declaration" in {

--- a/test/util/testdata/NotificationTestData.scala
+++ b/test/util/testdata/NotificationTestData.scala
@@ -17,7 +17,8 @@
 package testdata
 
 import java.time.format.DateTimeFormatter.ofPattern
-import java.time.{LocalDateTime, ZoneId}
+import java.time.temporal.ChronoUnit.MINUTES
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import java.util.UUID
 
 import play.api.http.{ContentTypes, HeaderNames}
@@ -233,9 +234,9 @@ object NotificationTestData {
   private lazy val functionCodesRandomised: Iterator[String] = Random.shuffle(functionCodes).toIterator
   private def randomResponseFunctionCode: String = functionCodesRandomised.next()
 
-  val dateTimeIssued: LocalDateTime = LocalDateTime.now()
-  val dateTimeIssued_2: LocalDateTime = dateTimeIssued.plusMinutes(3)
-  val dateTimeIssued_3: LocalDateTime = dateTimeIssued_2.plusMinutes(3)
+  val dateTimeIssued: ZonedDateTime = ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("UTC"))
+  val dateTimeIssued_2: ZonedDateTime = dateTimeIssued.plus(3, MINUTES)
+  val dateTimeIssued_3: ZonedDateTime = dateTimeIssued_2.plus(3, MINUTES)
   val functionCode: String = randomResponseFunctionCode
   val functionCode_2: String = randomResponseFunctionCode
   val functionCode_3: String = randomResponseFunctionCode

--- a/test/util/testdata/SubmissionTestData.scala
+++ b/test/util/testdata/SubmissionTestData.scala
@@ -16,21 +16,25 @@
 
 package testdata
 
-import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit.HOURS
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import java.util.UUID
 
-import uk.gov.hmrc.exports.models.declaration.submissions.{Action, CancellationRequest, Submission, SubmissionRequest}
 import testdata.ExportsTestData._
+import uk.gov.hmrc.exports.models.declaration.submissions.{Action, CancellationRequest, Submission, SubmissionRequest}
 
 object SubmissionTestData {
 
+  private val instant1971: ZonedDateTime = ZonedDateTime.of(LocalDateTime.of(1971, 1, 1, 1, 1), ZoneId.of("UTC"))
+  private val instant1972 = ZonedDateTime.of(LocalDateTime.of(1972, 1, 1, 1, 1), ZoneId.of("UTC"))
+
   lazy val action = Action(requestType = SubmissionRequest, id = actionId)
   lazy val action_2 =
-    Action(requestType = SubmissionRequest, id = actionId_2, requestTimestamp = LocalDateTime.of(1971, 1, 1, 1, 1))
+    Action(requestType = SubmissionRequest, id = actionId_2, requestTimestamp = instant1971)
   lazy val action_3 =
-    Action(requestType = SubmissionRequest, id = actionId_3, requestTimestamp = LocalDateTime.of(1972, 1, 1, 1, 1))
+    Action(requestType = SubmissionRequest, id = actionId_3, requestTimestamp = instant1972)
   lazy val actionCancellation =
-    Action(requestType = CancellationRequest, id = actionId, requestTimestamp = action.requestTimestamp.plusHours(3))
+    Action(requestType = CancellationRequest, id = actionId, requestTimestamp = action.requestTimestamp.plus(3, HOURS))
   lazy val submission: Submission =
     Submission(uuid = uuid, eori = eori, lrn = lrn, mrn = Some(mrn), ducr = ducr, actions = Seq(action))
   lazy val submission_2: Submission =


### PR DESCRIPTION
DMS sends the times in UTC time, but our BE microservice converts them
to `LocalDateTime` which strips them of the Zone information.

Converting the type to `Instant` as we did in the the Movements service
allows us to store the date from DMS as `UTC` or `Zulu time` and then on
the FE we just need to inform the view that we want to render that time
on British Time Zone `Europe/London`.

This ensures that we will see the time as `GMT/UTC` and `BST` depending
on the time of the year.

This holds true as long as DMS returns their dates in UTC.

This leaves us with a legacy time data in the `LocalDateTime` format.
I had two options:
 * Update the DB, by appending the `Z` (Zero Offset time AKA Zulu Time) to
   every timestamp. This is easily said than done, as the timestamps are
   within an array and the ineficciency of they MongoDB query update
   could prove an issue
 * Programatically deal with legacy and new data. This was the approach
   I chose.

Notification.scala
```
((__ \ "dateTimeIssued").read[Instant] or (__ \ "dateTimeIssued").read[Instant](readLocalDateTimeFromString))
```

Action.scala
```
((__ \ "requestTimestamp").read[Instant] or (__ \ "requestTimestamp").read[Instant](readLocalDateTimeFromString))
```

This allows the DAO layer to read two possible formats from the DB.