### PR TITLE
CEDS-2566 - extend stripping of new-lines for text-area inputs

### DIFF
--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilder.scala
@@ -16,11 +16,11 @@
 
 package uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
 
-import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 import javax.inject.Inject
 import uk.gov.hmrc.exports.models.declaration.{DocumentProduced, ExportItem}
+import uk.gov.hmrc.exports.services.mapping.CachingMappingHelper._
 import uk.gov.hmrc.exports.services.mapping.ModifyingBuilder
 import uk.gov.hmrc.wco.dec._
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
@@ -35,7 +35,7 @@ class AdditionalDocumentsBuilder @Inject()() extends ModifyingBuilder[ExportItem
 
   def buildThenAdd(exportItem: ExportItem, wcoGovernmentAgencyGoodsItem: GoodsShipment.GovernmentAgencyGoodsItem): Unit =
     exportItem.documentsProducedData.foreach {
-      _.documents.map(AdditionalDocumentsBuilder.createGoodsItemAdditionalDocument(_)).foreach { goodsItemAdditionalDocument =>
+      _.documents.map(AdditionalDocumentsBuilder.createGoodsItemAdditionalDocument).foreach { goodsItemAdditionalDocument =>
         wcoGovernmentAgencyGoodsItem.getAdditionalDocument
           .add(AdditionalDocumentsBuilder.createAdditionalDocument(goodsItemAdditionalDocument))
       }
@@ -147,7 +147,7 @@ object AdditionalDocumentsBuilder {
       id = doc.documentIdentifier,
       lpcoExemptionCode = doc.documentStatus,
       name = doc.documentStatusReason,
-      submitter = doc.issuingAuthorityName.map(name => GovernmentAgencyGoodsItemAdditionalDocumentSubmitter(name = Some(name))),
+      submitter = doc.issuingAuthorityName.map(name => GovernmentAgencyGoodsItemAdditionalDocumentSubmitter(name = Some(stripCarriageReturns(name)))),
       effectiveDateTime = doc.dateOfValidity
         .map(
           date => DateTimeElement(DateTimeString(formatCode = dateTimeCode, value = date.toLocalDate.format(DateTimeFormatter.ofPattern("yyyyMMdd"))))

--- a/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilder.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
 
 import javax.inject.Inject
 import uk.gov.hmrc.exports.models.declaration.{AdditionalInformation, ExportItem}
+import uk.gov.hmrc.exports.services.mapping.CachingMappingHelper._
 import uk.gov.hmrc.exports.services.mapping.ModifyingBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
 import wco.datamodel.wco.dec_dms._2.Declaration.AdditionalInformation.Pointer
@@ -77,7 +78,7 @@ class AdditionalInformationBuilder @Inject()() extends ModifyingBuilder[ExportIt
 
     if (info.description.nonEmpty) {
       val additionalInformationStatementDescriptionTextType = new AdditionalInformationStatementDescriptionTextType
-      additionalInformationStatementDescriptionTextType.setValue(info.description)
+      additionalInformationStatementDescriptionTextType.setValue(stripCarriageReturns(info.description))
       wcoAdditionalInformation.setStatementDescription(additionalInformationStatementDescriptionTextType)
     }
 

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilderSpec.scala
@@ -63,7 +63,7 @@ class AdditionalDocumentsBuilderSpec extends WordSpec with Matchers with Governm
         documentIdentifier = Some("idpart"),
         documentStatus = Some("status"),
         documentStatusReason = Some("reason"),
-        issuingAuthorityName = Some("issuingAuthority"),
+        issuingAuthorityName = Some("Issuing\nAuthority\rName"),
         dateOfValidity = Some(Date(Some(10), Some(4), Some(2017))),
         documentWriteOff = None
       )
@@ -76,6 +76,7 @@ class AdditionalDocumentsBuilderSpec extends WordSpec with Matchers with Governm
       additionalDoc.lpcoExemptionCode shouldBe Some("status")
       additionalDoc.name shouldBe Some("reason")
       additionalDoc.effectiveDateTime shouldBe Some(DateTimeElement(DateTimeString("102", "20170410")))
+      additionalDoc.submitter.flatMap(_.name) shouldBe Some("Issuing Authority Name")
     }
   }
 }

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilderSpec.scala
@@ -16,8 +16,8 @@
 
 package unit.uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem
 
+import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{Matchers, MustMatchers, WordSpec}
 import uk.gov.hmrc.exports.models.declaration.AdditionalInformation
 import uk.gov.hmrc.exports.services.mapping.governmentagencygoodsitem.AdditionalInformationBuilder
 import unit.uk.gov.hmrc.exports.services.mapping.ExportsItemBuilder
@@ -54,6 +54,18 @@ class AdditionalInformationBuilderSpec extends WordSpec with Matchers with Mocki
         .get(0)
         .getStatementDescription
         .getValue shouldBe additionalInformation.description
+    }
+
+    "remove new-lines from additional information description" in {
+      val exportItem = anItem(withAdditionalInformation(additionalInformation.copy(description = "some\ndescription")))
+      val governmentAgencyGoodsItem = new GovernmentAgencyGoodsItem()
+
+      builder.buildThenAdd(exportItem, governmentAgencyGoodsItem)
+
+      governmentAgencyGoodsItem.getAdditionalInformation
+        .get(0)
+        .getStatementDescription
+        .getValue shouldBe "some description"
     }
   }
 


### PR DESCRIPTION
Previously only doing commodity details description.
This adds same functionality to additional documents and additional information fields