### PR TITLE
CEDS-2695 Remove userId from unit tests for auth migration

### DIFF
--- a/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
@@ -98,7 +98,7 @@ trait CustomsExportsBaseSpec extends PlaySpec with GuiceOneAppPerSuite with Mock
 
   protected def postRequest(uri: String, body: JsValue, headers: Map[String, String] = Map.empty): FakeRequest[AnyContentAsJson] = {
     val session: Map[String, String] =
-      Map(SessionKeys.sessionId -> s"session-${UUID.randomUUID()}", SessionKeys.userId -> "Int-ba17b467-90f3-42b6-9570-73be7b78eb2b")
+      Map(SessionKeys.sessionId -> s"session-${UUID.randomUUID()}")
 
     FakeRequest("POST", uri)
       .withHeaders((Map(cfg.headerName -> token) ++ headers).toSeq: _*)


### PR DESCRIPTION
Remove deprecated SessionKeys userId attribute from unit tests