### PR TITLE
[CEDS-2800] Implement asynchronous notifications processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,8 @@ Inserted 1059 - 16 for GB1713564034
 Inserted 1471 - 412 for GB1026524884
 Inserted 2094 - 623 for GB1585987871
 ```
+
+### Feature flags
+To set a feature flag via system properties
+
+`sbt "run -Dmicroservice.features.exportsMigration=enabled"`

--- a/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/NotificationController.scala
@@ -25,6 +25,7 @@ import uk.gov.hmrc.exports.controllers.util.HeaderValidator
 import uk.gov.hmrc.exports.metrics.ExportsMetrics
 import uk.gov.hmrc.exports.metrics.MetricIdentifiers._
 import uk.gov.hmrc.exports.services.{NotificationService, SubmissionService}
+import uk.gov.hmrc.exports.models.declaration.notifications.Notification.FrontendFormat._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.xml.NodeSeq
@@ -46,7 +47,7 @@ class NotificationController @Inject()(
       case Some(submission) =>
         notificationsService
           .getNotifications(submission)
-          .map(notifications => Ok(notifications))
+          .map(notifications => Ok(notifications.filter(_.details.isDefined)))
       case _ => Future.successful(NotFound)
     }
   }
@@ -57,7 +58,7 @@ class NotificationController @Inject()(
     authorisedAction(bodyParsers.default) { implicit request =>
       notificationsService
         .getAllNotificationsForUser(request.eori.value)
-        .map(notifications => Ok(notifications))
+        .map(notifications => Ok(notifications.filter(_.details.isDefined)))
     }
 
   def saveNotification(): Action[NodeSeq] = Action.async(parse.xml) { implicit request =>

--- a/app/uk/gov/hmrc/exports/migrations/ExportsMigrationTool.scala
+++ b/app/uk/gov/hmrc/exports/migrations/ExportsMigrationTool.scala
@@ -80,7 +80,7 @@ class ExportsMigrationTool(
     this.enabled = enabled
 
   private def executeMigration(): Unit = {
-    logger.info("ExportsMigrationTool starting the data migration sequence..")
+    logger.info(s"ExportsMigrationTool starting the data migration sequence.. ${migrationsRegistry.migrations.size}")
 
     migrationsRegistry.migrations.sorted.foreach(executeIfNewOrRunAlways)
   }

--- a/app/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs.notification
+
+import java.util
+
+import com.mongodb.client.MongoDatabase
+import org.bson.Document
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.Filters.{and, exists, or, eq => feq}
+import org.mongodb.scala.model.UpdateOneModel
+import org.mongodb.scala.model.Updates.{combine, set, unset}
+import play.api.Logger
+import uk.gov.hmrc.exports.migrations.changelogs.{MigrationDefinition, MigrationInformation}
+
+import scala.collection.JavaConverters._
+
+class MakeParsedDetailsOptional extends MigrationDefinition {
+
+  private val logger = Logger(this.getClass)
+
+  private val INDEX_ID = "_id"
+  private val MRN = "mrn"
+  private val DATE_TIME_ISSUED = "dateTimeIssued"
+  private val STATUS = "status"
+  private val ERRORS = "errors"
+  private val DETAILS = "details"
+
+  private val collectionName = "notifications"
+
+  override val migrationInformation: MigrationInformation =
+    MigrationInformation(
+      id = "CEDS-2800 Make the parsed detail fields mrn, dateTimeIssued, status & error optional",
+      order = 1,
+      author = "Tim Wilkins",
+      runAlways = true
+    )
+
+  override def migrationFunction(db: MongoDatabase): Unit = {
+    logger.info(s"Applying '${migrationInformation.id}' db migration...")
+
+    val query = or(exists(MRN), exists(DATE_TIME_ISSUED), exists(STATUS), exists(ERRORS))
+    val queryBatchSize = 10
+    val updateBatchSize = 100
+
+    def createDetailsSubDoc(document: Document) = {
+      val mrn = document.get(MRN).asInstanceOf[String]
+      val dateTimeIssued = document.get(DATE_TIME_ISSUED).asInstanceOf[String]
+      val status = document.get(STATUS).asInstanceOf[String]
+      val errors = document.get(ERRORS, classOf[util.List[Document]])
+
+      new Document()
+        .append(MRN, mrn)
+        .append(DATE_TIME_ISSUED, dateTimeIssued)
+        .append(STATUS, status)
+        .append(ERRORS, errors)
+    }
+
+    getDocumentsToUpdate(db, query, queryBatchSize).map { document =>
+      val documentId = document.get(INDEX_ID)
+
+      val detailsSubDoc = createDetailsSubDoc(document)
+      logger.info(s"Creating new sub-document: $detailsSubDoc for documentId=$documentId")
+
+      val filter = and(feq(INDEX_ID, documentId))
+      val update = combine(unset(MRN), unset(DATE_TIME_ISSUED), unset(STATUS), unset(ERRORS), set(DETAILS, detailsSubDoc))
+      logger.info(s"[filter: $filter] [update: $update]")
+
+      new UpdateOneModel[Document](filter, update)
+    }.grouped(updateBatchSize).zipWithIndex.foreach {
+      case (requests, idx) =>
+        logger.info(s"Updating batch no. $idx...")
+
+        db.getCollection(collectionName).bulkWrite(seqAsJavaList(requests))
+        logger.info(s"Updated batch no. $idx")
+    }
+
+    logger.info(s"Applying '${migrationInformation.id}' db migration... Done.")
+  }
+
+  private def getDocumentsToUpdate(db: MongoDatabase, filter: Bson, queryBatchSize: Int) =
+    asScalaIterator(
+      db.getCollection(collectionName)
+        .find(filter)
+        .batchSize(queryBatchSize)
+        .iterator
+    )
+}

--- a/app/uk/gov/hmrc/exports/migrations/repositories/MongoRepository.scala
+++ b/app/uk/gov/hmrc/exports/migrations/repositories/MongoRepository.scala
@@ -53,14 +53,19 @@ abstract class MongoRepository private[migrations] (val mongoDatabase: MongoData
     }
 
   // Index is considered unique when:
-  // 1. Every uniqueField value is equal 1
-  // 2. "ns" field contains fullCollectionName
-  // 3. "unique" field is true
+  // 1. Name is "_id_" (these are implicitly unique https://docs.mongodb.com/manual/indexes/index.html#default-id-index)
+  // 2. Every uniqueField value is equal 1
+  // 3. "ns" field contains fullCollectionName
+  // 4. "unique" field is true
   private def isIndexUnique(index: Document): Boolean = {
     val key = index.get("key").asInstanceOf[Document]
+
+    if (index.getString("name").equals("_id_")) return true
+
     for (uniqueField <- uniqueFields) {
       if (key.getInteger(uniqueField, 0) != 1) return false
     }
+
     fullCollectionName == index.getString("ns") && index.getBoolean("unique", false)
   }
 

--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
@@ -22,30 +22,61 @@ import play.api.libs.functional.syntax._
 import play.api.libs.json.{Json, Reads, _}
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.SubmissionStatus
 
-case class Notification(
-  actionId: String,
-  mrn: String,
-  dateTimeIssued: ZonedDateTime,
-  status: SubmissionStatus,
-  errors: Seq[NotificationError],
-  payload: String
-)
+case class NotificationDetails(mrn: String, dateTimeIssued: ZonedDateTime, status: SubmissionStatus, errors: Seq[NotificationError])
 
-object Notification {
+object NotificationDetails {
   implicit val readLocalDateTimeFromString: Reads[ZonedDateTime] = implicitly[Reads[LocalDateTime]]
     .map(ZonedDateTime.of(_, ZoneId.of("UTC")))
 
-  implicit val writes: OWrites[Notification] = Json.writes[Notification]
-  implicit val reads: Reads[Notification] =
-    ((__ \ "actionId").read[String] and
-      (__ \ "mrn").read[String] and
+  implicit val writes: OWrites[NotificationDetails] = Json.writes[NotificationDetails]
+  implicit val reads: Reads[NotificationDetails] =
+    ((__ \ "mrn").read[String] and
       ((__ \ "dateTimeIssued").read[ZonedDateTime] or (__ \ "dateTimeIssued").read[ZonedDateTime](readLocalDateTimeFromString)) and
       (__ \ "status").read[SubmissionStatus] and
-      (__ \ "errors").read[Seq[NotificationError]] and
-      (__ \ "payload").read[String])(Notification.apply _)
+      (__ \ "errors").read[Seq[NotificationError]])(NotificationDetails.apply _)
 
-  implicit val notificationsReads: Reads[Seq[Notification]] = Reads.seq(reads)
-  implicit val notificationsWrites: Writes[Seq[Notification]] = Writes.seq(writes)
+  implicit val format: Format[NotificationDetails] = Format(reads, writes)
+}
 
-  implicit val format: Format[Notification] = Format(reads, writes)
+case class Notification(actionId: String, payload: String, details: Option[NotificationDetails])
+
+object Notification {
+
+  object DbFormat {
+    implicit val writes: Writes[Notification] =
+      ((JsPath \ "actionId").write[String] and
+        (JsPath \ "payload").write[String] and
+        (JsPath \ "details").writeNullable[NotificationDetails](NotificationDetails.writes))(unlift(Notification.unapply))
+
+    implicit val reads: Reads[Notification] =
+      ((__ \ "actionId").read[String] and
+        (__ \ "payload").read[String] and
+        (__ \ "details").readNullable[NotificationDetails])(Notification.apply _)
+
+    implicit val notificationsReads: Reads[Seq[Notification]] = Reads.seq(reads)
+    implicit val notificationsWrites: Writes[Seq[Notification]] = Writes.seq(writes)
+
+    implicit val format: Format[Notification] = Format(reads, writes)
+  }
+
+  object FrontendFormat {
+    implicit val writes: Writes[Notification] = new Writes[Notification] {
+
+      def writes(notification: Notification) =
+        notification.details.map { details =>
+          Json.obj(
+            "actionId" -> notification.actionId,
+            "mrn" -> details.mrn,
+            "dateTimeIssued" -> details.dateTimeIssued,
+            "status" -> details.status,
+            "errors" -> details.errors,
+            "payload" -> notification.payload
+          )
+        }.getOrElse {
+          Json.obj("actionId" -> notification.actionId, "payload" -> notification.payload)
+        }
+    }
+
+    implicit val notificationsWrites: Writes[Seq[Notification]] = Writes.seq(writes)
+  }
 }

--- a/app/uk/gov/hmrc/exports/routines/ReattemptNotificationParsingRoutine.scala
+++ b/app/uk/gov/hmrc/exports/routines/ReattemptNotificationParsingRoutine.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.routines
+
+import javax.inject.Inject
+import play.api.Logger
+import uk.gov.hmrc.exports.services.NotificationService
+
+import scala.concurrent.Future
+
+class ReattemptNotificationParsingRoutine @Inject()(notificationService: NotificationService)(implicit mec: RoutinesExecutionContext)
+    extends Routine {
+  private val logger = Logger(this.getClass)
+
+  def execute(): Future[Unit] = {
+    logger.info("Starting NotificationService.reattemptParsingUnparsedNotifications()...")
+    notificationService.reattemptParsingUnparsedNotifications().map { _ =>
+      logger.info("Finished NotificationService.reattemptParsingUnparsedNotifications()")
+    }
+  }
+}

--- a/app/uk/gov/hmrc/exports/routines/Routine.scala
+++ b/app/uk/gov/hmrc/exports/routines/Routine.scala
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.exports.mongock
+package uk.gov.hmrc.exports.routines
 
-import akka.actor.ActorSystem
-import javax.inject.{Inject, Singleton}
-import play.api.libs.concurrent.CustomExecutionContext
+import scala.concurrent.Future
 
-@Singleton
-class MigrationExecutionContext @Inject()(actorSystem: ActorSystem) extends CustomExecutionContext(actorSystem, "contexts.migration-dispatcher") {}
+trait Routine {
+  def execute(): Future[Unit]
+}

--- a/app/uk/gov/hmrc/exports/routines/RoutineRunner.scala
+++ b/app/uk/gov/hmrc/exports/routines/RoutineRunner.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.routines
+
+import akka.actor.{ActorSystem, Cancellable}
+import javax.inject.Inject
+import play.api.inject.ApplicationLifecycle
+import uk.gov.hmrc.exports.migrations.MigrationRoutine
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class RoutineRunner @Inject()(
+  migrationRunner: MigrationRoutine,
+  reattemptParsing: ReattemptNotificationParsingRoutine,
+  actorSystem: ActorSystem,
+  applicationLifecycle: ApplicationLifecycle
+)(implicit mec: RoutinesExecutionContext) {
+
+  val migrationTask: Cancellable = actorSystem.scheduler.scheduleOnce(0.seconds) {
+    for {
+      _ <- migrationRunner.execute()
+      _ <- reattemptParsing.execute()
+    } yield (())
+  }
+
+  applicationLifecycle.addStopHook(() => Future.successful(migrationTask.cancel()))
+}

--- a/app/uk/gov/hmrc/exports/routines/RoutineRunnerModule.scala
+++ b/app/uk/gov/hmrc/exports/routines/RoutineRunnerModule.scala
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.exports.migrations
+package uk.gov.hmrc.exports.routines
 
 import play.api.inject._
 
-class ExportsMigrationModule extends SimpleModule(bind[MigrationRunner].toSelf.eagerly())
+class RoutineRunnerModule extends SimpleModule(bind[RoutineRunner].toSelf.eagerly())

--- a/app/uk/gov/hmrc/exports/routines/RoutinesExecutionContext.scala
+++ b/app/uk/gov/hmrc/exports/routines/RoutinesExecutionContext.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.routines
+
+import akka.actor.ActorSystem
+import javax.inject.{Inject, Singleton}
+import play.api.libs.concurrent.CustomExecutionContext
+
+@Singleton
+class RoutinesExecutionContext @Inject()(actorSystem: ActorSystem) extends CustomExecutionContext(actorSystem, "contexts.routines-dispatcher") {}

--- a/app/uk/gov/hmrc/exports/services/SubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/SubmissionService.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
 import uk.gov.hmrc.exports.models.Eori
 import uk.gov.hmrc.exports.models.declaration.submissions._
 import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration}
+import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.services.mapping.CancellationMetaDataBuilder
 import uk.gov.hmrc.http.HeaderCarrier
@@ -81,9 +82,9 @@ class SubmissionService @Inject()(
   private def appendMRNIfAlreadyAvailable(submission: Submission, actionId: String): Future[Submission] =
     notificationRepository.findNotificationsByActionId(actionId).flatMap { notifications =>
       notifications.headOption match {
-        case Some(notification) =>
-          submissionRepository.updateMrn(actionId, notification.mrn).map(_.getOrElse(submission))
-        case None => Future.successful(submission)
+        case Some(Notification(_, _, Some(details))) =>
+          submissionRepository.updateMrn(actionId, details.mrn).map(_.getOrElse(submission))
+        case _ => Future.successful(submission)
       }
     }
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -52,7 +52,7 @@ play.modules.enabled += "play.modules.reactivemongo.ReactiveMongoHmrcModule"
 
 
 play.modules.enabled += "uk.gov.hmrc.exports.scheduler.Module"
-play.modules.enabled += "uk.gov.hmrc.exports.migrations.ExportsMigrationModule"
+play.modules.enabled += "uk.gov.hmrc.exports.routines.RoutineRunnerModule"
 
 # Session Timeout
 # ~~~~
@@ -182,7 +182,7 @@ microservice {
 
     features {
         default = disabled
-        exportsMigration = disabled
+        exportsMigration = enabled
     }
 }
 
@@ -202,7 +202,7 @@ scheduler {
 play.http.parser.maxMemoryBuffer=10M
 
 contexts {
-    migration-dispatcher {
+    routines-dispatcher {
         fork-join-executor {
             parallelism-min = 2
             parallalism-factor = 2.0

--- a/precheck.sh
+++ b/precheck.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sbt clean coverage test it:test scalafmt::test test:scalafmt::test coverageReport
+sbt clean coverage test it:test scalafmt::test test:scalafmt::test scalastyle coverageReport

--- a/test/it/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptionalSpec.scala
+++ b/test/it/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptionalSpec.scala
@@ -1,0 +1,125 @@
+package uk.gov.hmrc.exports.migrations.changelogs.notification
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mongodb.{MongoClient, MongoClientURI}
+import com.mongodb.client.{MongoCollection, MongoDatabase}
+import org.bson.Document
+import org.scalatest.{BeforeAndAfterEach, MustMatchers, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import stubs.TestMongoDB
+import stubs.TestMongoDB.mongoConfiguration
+import MakeParsedDetailsOptionalSpec._
+
+class MakeParsedDetailsOptionalSpec extends WordSpec with MustMatchers with GuiceOneServerPerSuite with BeforeAndAfterEach {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[com.kenshoo.play.metrics.PlayModule]
+      .configure(mongoConfiguration)
+      .build()
+
+  private val MongoURI = mongoConfiguration.get[String]("mongodb.uri")
+  private val DatabaseName = TestMongoDB.DatabaseName
+  private val CollectionName = "notifications"
+
+  private implicit val mongoDatabase: MongoDatabase = {
+    val uri = new MongoClientURI(MongoURI.replaceAllLiterally("sslEnabled", "ssl"))
+    val client = new MongoClient(uri)
+
+    client.getDatabase(DatabaseName)
+  }
+
+  private val changeLog = new MakeParsedDetailsOptional()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    mongoDatabase.getCollection(CollectionName).drop()
+  }
+
+  override def afterEach(): Unit = {
+    mongoDatabase.getCollection(CollectionName).drop()
+    super.afterEach()
+  }
+
+  private def getDeclarationsCollection(db: MongoDatabase): MongoCollection[Document] = mongoDatabase.getCollection(CollectionName)
+
+  "MakeParsedDetailsOptional migration definition" should {
+
+    "correctly migrate records from previous format" in {
+      runTest(testDataBeforeChangeSet_1, testDataAfterChangeSet_1)(changeLog.migrationFunction)
+    }
+
+    "not change records already migrated" in {
+      runTest(testDataAfterChangeSet_1, testDataAfterChangeSet_1)(changeLog.migrationFunction)
+    }
+
+    "not change records that were not yet parsed" in {
+      runTest(testDataUnparsableNotification, testDataUnparsableNotification)(changeLog.migrationFunction)
+    }
+  }
+
+  private def runTest(inputDataJson: String, expectedDataJson: String)(test: MongoDatabase => Unit)(implicit mongoDatabase: MongoDatabase): Unit = {
+    getDeclarationsCollection(mongoDatabase).insertOne(Document.parse(inputDataJson))
+
+    test(mongoDatabase)
+
+    val result: Document = getDeclarationsCollection(mongoDatabase).find().first()
+    val expectedResult: String = expectedDataJson
+
+    compareJson(result.toJson, expectedResult)
+  }
+
+  private def compareJson(actual: String, expected: String): Unit = {
+    val mapper = new ObjectMapper
+
+    val jsonActual = mapper.readTree(actual)
+    val jsonExpected = mapper.readTree(expected)
+
+    jsonActual mustBe jsonExpected
+  }
+}
+
+object MakeParsedDetailsOptionalSpec {
+  val testDataBeforeChangeSet_1: String =
+    """{
+                                            |    "_id" : "5fc0d62750c11c0797a2456f",
+                                            |    "actionId" : "b1c09f1b-7c94-4e90-b754-7c5c71c44e11",
+                                            |    "mrn" : "MRN87878797",
+                                            |    "dateTimeIssued" : "2020-11-27T10:37:10.918Z[UTC]",
+                                            |    "status" : "UNKNOWN",
+                                            |    "errors" : [
+                                            |        {
+                                            |            "validationCode" : "CDS12056",
+                                            |            "pointer" : "42A"
+                                            |        }
+                                            |    ],
+                                            |    "payload" : "RhzDC5lT6ZrWSCHrtoy6wUkL2VdjXLNm8N6PdbyFLpE1jnBqigGsgHuS4CrPO5J8vLtkUZZe0nkNseSa9x5Epb3yuOgZYB6uV272UwCx2utsdqb2U5XEblaYNaWUdifZl9IJVNo39yy0A3XpWdB3avkKCxSn1qNW5Ar3CE4uSi1D5C4oEFUDoQqo484Y9Kt8BtQsabBzC8IaR2vUMhOEJHk5j7HJDIeQ0JGujOWY9QBm13LfAYfBoIrM3GYBJcgR45L9NfVIwVAlkkXbtsaqdVwpRyuayuy8VYyyhyFk4Uc3"
+                                            |}""".stripMargin
+
+  val testDataAfterChangeSet_1: String =
+    """{
+                                           |    "_id" : "5fc0d62750c11c0797a2456f",
+                                           |    "actionId" : "b1c09f1b-7c94-4e90-b754-7c5c71c44e11",
+                                           |    "payload" : "RhzDC5lT6ZrWSCHrtoy6wUkL2VdjXLNm8N6PdbyFLpE1jnBqigGsgHuS4CrPO5J8vLtkUZZe0nkNseSa9x5Epb3yuOgZYB6uV272UwCx2utsdqb2U5XEblaYNaWUdifZl9IJVNo39yy0A3XpWdB3avkKCxSn1qNW5Ar3CE4uSi1D5C4oEFUDoQqo484Y9Kt8BtQsabBzC8IaR2vUMhOEJHk5j7HJDIeQ0JGujOWY9QBm13LfAYfBoIrM3GYBJcgR45L9NfVIwVAlkkXbtsaqdVwpRyuayuy8VYyyhyFk4Uc3",
+                                           |    "details" : {
+                                           |        "mrn" : "MRN87878797",
+                                           |        "dateTimeIssued" : "2020-11-27T10:37:10.918Z[UTC]",
+                                           |        "status" : "UNKNOWN",
+                                           |        "errors" : [
+                                           |            {
+                                           |                "validationCode" : "CDS12056",
+                                           |                "pointer" : "42A"
+                                           |            }
+                                           |        ]
+                                           |    }
+                                           |}""".stripMargin
+
+  val testDataUnparsableNotification: String =
+    """{
+                                           |    "_id" : "5fc0d62750c11c0797a2456f",
+                                           |    "actionId" : "b1c09f1b-7c94-4e90-b754-7c5c71c44e11",
+                                           |    "payload" : "RhzDC5lT6ZrWSCHrtoy6wUkL2VdjXLNm8N6PdbyFLpE1jnBqigGsgHuS4CrPO5J8vLtkUZZe0nkNseSa9x5Epb3yuOgZYB6uV272UwCx2utsdqb2U5XEblaYNaWUdifZl9IJVNo39yy0A3XpWdB3avkKCxSn1qNW5Ar3CE4uSi1D5C4oEFUDoQqo484Y9Kt8BtQsabBzC8IaR2vUMhOEJHk5j7HJDIeQ0JGujOWY9QBm13LfAYfBoIrM3GYBJcgR45L9NfVIwVAlkkXbtsaqdVwpRyuayuy8VYyyhyFk4Uc3"
+                                           |}""".stripMargin
+}

--- a/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/CustomsExportsBaseSpec.scala
@@ -46,9 +46,9 @@ import uk.gov.hmrc.exports.repositories.{NotificationRepository, SubmissionRepos
 import uk.gov.hmrc.exports.services.WcoSubmissionService
 import uk.gov.hmrc.http.SessionKeys
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag
 
 trait CustomsExportsBaseSpec extends PlaySpec with GuiceOneAppPerSuite with MockitoSugar with ScalaFutures with AuthTestSupport {

--- a/test/unit/uk/gov/hmrc/exports/models/declaration/notifications/NotificationsSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/models/declaration/notifications/NotificationsSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.models.declaration.notifications
+
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
+import java.time.format.DateTimeFormatter
+
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.libs.json.Json
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
+
+class NotificationsSpec extends WordSpec with MustMatchers {
+
+  val formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME
+
+  "Notifications Spec" must {
+    val actionId = "123"
+    val dateTime = LocalDateTime.now()
+    val mrn = "id1"
+    val payload = "<xml></xml>"
+
+    val notification = Notification(
+      actionId,
+      payload,
+      Some(NotificationDetails(mrn, ZonedDateTime.of(dateTime, ZoneId.of("UCT")), SubmissionStatus.ACCEPTED, Seq.empty))
+    )
+
+    "have json writes that produce object which could be parsed by the front end service" in {
+      val json = Json.toJson(notification)(Notification.FrontendFormat.writes)
+
+      json.toString() mustBe NotificationsSpec.serialisedWithNonOptionalDetailsFormat(
+        actionId,
+        mrn,
+        dateTime.atZone(ZoneId.of("UCT")).format(formatter),
+        payload
+      )
+    }
+
+    "have json writes that produce object which could be parsed by the database" in {
+      val json = Json.toJson(notification)(Notification.DbFormat.writes)
+
+      json.toString() mustBe NotificationsSpec.serialisedWithOptionalDetailsFormat(
+        actionId,
+        mrn,
+        dateTime.atZone(ZoneId.of("UCT")).format(formatter),
+        payload
+      )
+    }
+  }
+}
+
+object NotificationsSpec {
+  def serialisedWithNonOptionalDetailsFormat(actionId: String, mrn: String, dateTime: String, payload: String) =
+    s"""{"actionId":"${actionId}","mrn":"${mrn}","dateTimeIssued":"${dateTime}","status":"ACCEPTED","errors":[],"payload":"${payload}"}"""
+
+  def serialisedWithOptionalDetailsFormat(actionId: String, mrn: String, dateTime: String, payload: String) =
+    s"""{"actionId":"${actionId}","payload":"${payload}","details":{"mrn":"${mrn}","dateTimeIssued":"${dateTime}","status":"ACCEPTED","errors":[]}}"""
+}

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -28,7 +28,7 @@ import testdata.ExportsDeclarationBuilder
 import testdata.ExportsTestData._
 import testdata.SubmissionTestData._
 import uk.gov.hmrc.exports.connectors.CustomsDeclarationsConnector
-import uk.gov.hmrc.exports.models.declaration.notifications.Notification
+import uk.gov.hmrc.exports.models.declaration.notifications.{Notification, NotificationDetails}
 import uk.gov.hmrc.exports.models.declaration.submissions._
 import uk.gov.hmrc.exports.models.declaration.{DeclarationStatus, ExportsDeclaration}
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, NotificationRepository, SubmissionRepository}
@@ -123,7 +123,12 @@ class SubmissionServiceSpec
 
     "submit to the Dec API" when {
       val declaration = aDeclaration()
-      val notification = Notification("id", "mrn", ZonedDateTime.of(LocalDateTime.now(), ZoneOffset.UTC), SubmissionStatus.ACCEPTED, Seq.empty, "xml")
+
+      val notification = Notification(
+        "id1",
+        "xml",
+        Some(NotificationDetails("mrn", ZonedDateTime.of(LocalDateTime.now(), ZoneOffset.UTC), SubmissionStatus.ACCEPTED, Seq.empty))
+      )
       val submission = Submission(declaration, "lrn", "mrn")
 
       "valid declaration" in {

--- a/test/util/testdata/ExportsTestData.scala
+++ b/test/util/testdata/ExportsTestData.scala
@@ -35,6 +35,7 @@ object ExportsTestData {
   val actionId: String = "b1c09f1b-7c94-4e90-b754-7c5c71c44e11"
   val actionId_2: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e22"
   val actionId_3: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e33"
+  val actionId_4: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e44"
 
   val authToken: String =
     "BXQ3/Treo4kQCZvVcCqKPlwxRN4RA9Mb5RF8fFxOuwG5WSg+S+Rsp9Nq998Fgg0HeNLXL7NGwEAIzwM6vuA6YYhRQnTRFaBhrp+1w+kVW8g1qHGLYO48QPWuxdM87VMCZqxnCuDoNxVn76vwfgtpNj0+NwfzXV2Zc12L2QGgF9H9KwIkeIPK/mMlBESjue4V]"

--- a/test/util/testdata/NotificationTestData.scala
+++ b/test/util/testdata/NotificationTestData.scala
@@ -25,7 +25,7 @@ import play.api.http.{ContentTypes, HeaderNames}
 import play.api.mvc.Codec
 import uk.gov.hmrc.exports.controllers.util.CustomsHeaderNames
 import uk.gov.hmrc.exports.models.{Pointer, PointerSection, PointerSectionType}
-import uk.gov.hmrc.exports.models.declaration.notifications.{Notification, NotificationError}
+import uk.gov.hmrc.exports.models.declaration.notifications.{Notification, NotificationDetails, NotificationError}
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
 import testdata.ExportsTestData._
 
@@ -148,6 +148,40 @@ object NotificationTestData {
       </Response>
     </MetaData>
 
+  def exampleNotificationWithUnparsableXML(
+    mrn: String,
+    dateTime_received: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(ofPattern("yyyyMMddHHmmssX")),
+    dateTime_accepted: String = LocalDateTime.now().plusHours(1).atZone(ZoneId.of("UCT")).format(ofPattern("yyyyMMddHHmmssX"))
+  ): Elem =
+    <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
+      <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
+      <WCOTypeName>RES</WCOTypeName>
+      <ResponsibleCountryCode/>
+      <ResponsibleAgencyName/>
+      <AgencyAssignedCustomizationCode/>
+      <AgencyAssignedCustomizationVersionCode/>
+      <Response>
+        <FunctionCode>02</FunctionCode>
+        <FunctionalReferenceID>1234555</FunctionalReferenceID>
+        <IssueDateTime>
+          <DateTimeString formatCode="304">{dateTime_received}</DateTimeString>
+        </IssueDateTime>
+        <Declaration>
+          <ID>{mrn}</ID>
+        </Declaration>
+      </Response>
+      <Response>
+        <FunctionCode>01</FunctionCode>
+        <FunctionalReferenceID>1234567890</FunctionalReferenceID>
+        <wrong>
+          <DateTimeString formatCode="304">{dateTime_accepted}</DateTimeString>
+        </wrong>
+        <Declaration>
+          <ID>{mrn}</ID>
+        </Declaration>
+      </Response>
+    </MetaData>
+
   def exampleNotificationInIncorrectFormatXML(
     mrn: String,
     dateTime: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(ofPattern("yyyyMMddHHmmssX"))
@@ -247,39 +281,29 @@ object NotificationTestData {
   val payload = TestDataHelper.randomAlphanumericString(payloadExemplaryLength)
   val payload_2 = TestDataHelper.randomAlphanumericString(payloadExemplaryLength)
   val payload_3 = TestDataHelper.randomAlphanumericString(payloadExemplaryLength)
+  val payload_4 = TestDataHelper.randomAlphanumericString(payloadExemplaryLength)
 
   def exampleNotification(conversationId: String = UUID.randomUUID().toString) = Notification(
     actionId = actionId,
-    mrn = mrn,
-    dateTimeIssued = dateTimeIssued,
-    status = SubmissionStatus.UNKNOWN,
-    errors = errors,
-    payload = payload
+    payload = payload,
+    details = Some(NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = SubmissionStatus.UNKNOWN, errors = errors))
   )
 
   val notification = Notification(
     actionId = actionId,
-    mrn = mrn,
-    dateTimeIssued = dateTimeIssued,
-    status = SubmissionStatus.UNKNOWN,
-    errors = errors,
-    payload = payload
+    payload = payload,
+    details = Some(NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = SubmissionStatus.UNKNOWN, errors = errors))
   )
   val notification_2 = Notification(
     actionId = actionId,
-    mrn = mrn,
-    dateTimeIssued = dateTimeIssued_2,
-    status = SubmissionStatus.UNKNOWN,
-    errors = errors,
-    payload = payload_2
+    payload = payload_2,
+    details = Some(NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_2, status = SubmissionStatus.UNKNOWN, errors = errors))
   )
   val notification_3 = Notification(
     actionId = actionId_2,
-    mrn = mrn,
-    dateTimeIssued = dateTimeIssued_3,
-    status = SubmissionStatus.UNKNOWN,
-    errors = Seq.empty,
-    payload = payload_3
+    payload = payload_3,
+    details = Some(NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_3, status = SubmissionStatus.UNKNOWN, errors = Seq.empty))
   )
 
+  val notificationUnparsable = Notification(actionId = actionId_4, payload = payload_4, details = None)
 }


### PR DESCRIPTION
Before all Notification processing was a synchronous operation. In cases
where the service can not parse a Notification due to a change in its
structure, the notification data is lost as it is not inserted into
the MongoDB.

The implemented solution is:
1) The data parsed from a notification is now optional in the data
model.
2) All notifications payloads received are persisted to Mongo if they
are parsable or not.
3) A reattempt to parse 'routine' is run at app start up (after the
database migration jobs have finished) to query all unparsed
notifications and attempt to reprocess them.
4) A new database migration job created to migrate from the non-optional
notification parsed details model to the new optional structure.