### PR TITLE
[CEDS-2800] Fix index naming clash of new indexes with old

### DIFF
--- a/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
@@ -37,8 +37,8 @@ class NotificationRepository @Inject()(mc: ReactiveMongoComponent)(implicit ec: 
     mongo().collection[JSONCollection](collectionName, failoverStrategy = RepositorySettings.failoverStrategy)
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq("details.dateTimeIssued" -> IndexType.Ascending), name = Some("dateTimeIssuedIdx")),
-    Index(Seq("details.mrn" -> IndexType.Ascending), name = Some("mrnIdx")),
+    Index(Seq("details.dateTimeIssued" -> IndexType.Ascending), name = Some("detailsDateTimeIssuedIdx")),
+    Index(Seq("details.mrn" -> IndexType.Ascending), name = Some("detailsMrnIdx")),
     Index(Seq("actionId" -> IndexType.Ascending), name = Some("actionIdIdx")),
     Index(Seq("details" -> IndexType.Ascending), name = Some("detailsMissingIdx"), partialFilter = Some(BSONDocument("details" -> BSONNull)))
   )


### PR DESCRIPTION
Two of the existing indexes were built on fields that
have now been moved into a sub-document. The index
fields were changed accordingly but their names remained
the same causing a clash when applied to the
existing collections in the different environments.

The modified indexes have now been renamed to make them
distinct from the previous versions of themselves. Also
the db migration job now also deletes the old versions
of these indexes to clean up.