### PR TITLE
[CEDS-2800] Reduce query batch size for db migrations

### DIFF
--- a/app/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
@@ -51,11 +51,11 @@ class MakeParsedDetailsOptional extends MigrationDefinition {
     )
 
   override def migrationFunction(db: MongoDatabase): Unit = {
-    logger.info(s"Applying '${migrationInformation.id}' db migration...")
+    logger.info(s"Applying '${migrationInformation.id}' db migration... ")
 
     val query = or(exists(MRN), exists(DATE_TIME_ISSUED), exists(STATUS), exists(ERRORS))
     val queryBatchSize = 10
-    val updateBatchSize = 100
+    val updateBatchSize = 10
 
     def createDetailsSubDoc(document: Document) = {
       val mrn = document.get(MRN).asInstanceOf[String]


### PR DESCRIPTION
Currently the db migration code starts in QA but never
finishes (without throwing any errors or exceptions).

It is suspected that there might be a memory limit on
mongo on the platform that we are exceeding by trying
to run 100 update queries at a time. s

So now reducing this number to 10 to see if that makes
a difference.