### PR TITLE
[CEDS-2800] Drop misconfigured index

### DIFF
--- a/app/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/notification/MakeParsedDetailsOptional.scala
@@ -51,7 +51,7 @@ class MakeParsedDetailsOptional extends MigrationDefinition {
     )
 
   override def migrationFunction(db: MongoDatabase): Unit = {
-    logger.info(s"Applying '${migrationInformation.id}' db migration... ")
+    logger.info(s"Applying '${migrationInformation.id}' db migration...  ")
 
     val query = or(exists(MRN), exists(DATE_TIME_ISSUED), exists(STATUS), exists(ERRORS))
     val queryBatchSize = 10
@@ -72,7 +72,7 @@ class MakeParsedDetailsOptional extends MigrationDefinition {
 
     val collection = db.getCollection(collectionName)
 
-    val redundantIndexesToBeDeleted = Vector("dateTimeIssuedIdx", "mrnIdx")
+    val redundantIndexesToBeDeleted = Vector("dateTimeIssuedIdx", "mrnIdx", "detailsMissingIdx")
     collection.listIndexes().iterator().forEachRemaining { idx =>
       val indexName = idx.getString("name")
       if (redundantIndexesToBeDeleted.contains(indexName))

--- a/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/NotificationRepository.scala
@@ -40,7 +40,7 @@ class NotificationRepository @Inject()(mc: ReactiveMongoComponent)(implicit ec: 
     Index(Seq("details.dateTimeIssued" -> IndexType.Ascending), name = Some("detailsDateTimeIssuedIdx")),
     Index(Seq("details.mrn" -> IndexType.Ascending), name = Some("detailsMrnIdx")),
     Index(Seq("actionId" -> IndexType.Ascending), name = Some("actionIdIdx")),
-    Index(Seq("details" -> IndexType.Ascending), name = Some("detailsMissingIdx"), partialFilter = Some(BSONDocument("details" -> BSONNull)))
+    Index(Seq("details" -> IndexType.Ascending), name = Some("detailsDocMissingIdx"), partialFilter = Some(BSONDocument("details" -> BSONNull)))
   )
 
   // TODO: Need to change this method to return Future[WriteResult].


### PR DESCRIPTION
Original definition of index 'detailsMissingIdx' used the
wrong filter (where doc exists rather than where doc does
not exist!)

Dropping index 'detailsMissingIdx' and re-creating it with
new fliter as 'detailsDocMissingIdx'.