### PR TITLE
[CEDS-2888] Auto set routing country to GB

### DIFF
--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/consignment/IteneraryBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/consignment/IteneraryBuilderSpec.scala
@@ -69,6 +69,32 @@ class IteneraryBuilderSpec extends WordSpec with Matchers with ExportsDeclaratio
         consignment.getItinerary.get(0).getRoutingCountryCode.getValue shouldBe "GB"
         consignment.getItinerary.get(1).getRoutingCountryCode.getValue shouldBe "FR"
       }
+
+      "no routing countries are provided and origin is GB" in {
+        // Given
+        val model = aDeclaration(withRoutingCountries(Seq()), withOriginationCountry(Country(Some("GB"))))
+        val consignment = new Declaration.Consignment()
+
+        // When
+        new IteneraryBuilder().buildThenAdd(model, consignment)
+
+        // Then
+        consignment.getItinerary should have(size(1))
+        consignment.getItinerary.get(0).getSequenceNumeric.intValue shouldBe 0
+        consignment.getItinerary.get(0).getRoutingCountryCode.getValue shouldBe "GB"
+      }
+
+      "no routing countries are provided and origin is not GB" in {
+        // Given
+        val model = aDeclaration(withRoutingCountries(Seq()), withOriginationCountry(Country(Some("FR"))))
+        val consignment = new Declaration.Consignment()
+
+        // When
+        new IteneraryBuilder().buildThenAdd(model, consignment)
+
+        // Then
+        consignment.getItinerary should have(size(0))
+      }
     }
   }
 }


### PR DESCRIPTION
DMS rules state that if the origin country is set
to GB then the routing country must also be set as
GB.

Users are understandably unaware of this rule so
have been not setting a routing country when
exporting goods from GB to other countries.

To reduce the number of declarations falling fowl
of this and being rejected we will now automatically
set the routing country to GB if the originating
country is GB and no routing countries are specified
by the user.