### PR TITLE
CEDS-2975 Trigger email sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This is a placeholder README.md for a new repository
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html")
 
+### Required services
+
+In order to set up all services required for customs-declare-exports to work, there are profiles in service-manager-config repository:
+- CDS_EXPORTS_DECLARATION_DEPS - all services EXCEPT both declarations services
+- CDS_EXPORTS_DECLARATION_ALL - all services together with both declarations services
+
 ### Scalastyle
 
 Project contains scalafmt plugin.

--- a/app/uk/gov/hmrc/exports/connectors/CustomsDeclarationsConnector.scala
+++ b/app/uk/gov/hmrc/exports/connectors/CustomsDeclarationsConnector.scala
@@ -26,6 +26,7 @@ import play.mvc.Http.Status.ACCEPTED
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.exports.controllers.util.CustomsHeaderNames
 import uk.gov.hmrc.exports.models.CustomsDeclarationsResponse
+import uk.gov.hmrc.http.HttpReads.is4xx
 import uk.gov.hmrc.http.{HttpClient, _}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -70,8 +71,8 @@ class CustomsDeclarationsConnector @Inject()(appConfig: AppConfig, httpClient: H
           logger.error(s"Error during submitting declaration: ${error.getMessage}")
 
           error match {
-            case exWithHeaders: Upstream4xxResponse =>
-              val conversationId = exWithHeaders.headers.get("X-Conversation-ID") match {
+            case response: UpstreamErrorResponse if is4xx(response.statusCode) =>
+              val conversationId = response.headers.get("X-Conversation-ID") match {
                 case Some(data) => data.head
                 case None       => "No conversation ID found"
               }

--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/Notification.scala
@@ -16,31 +16,17 @@
 
 package uk.gov.hmrc.exports.models.declaration.notifications
 
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
-
 import play.api.libs.functional.syntax._
 import play.api.libs.json.{Json, Reads, _}
-import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.SubmissionStatus
 
-case class NotificationDetails(mrn: String, dateTimeIssued: ZonedDateTime, status: SubmissionStatus, errors: Seq[NotificationError])
-
-object NotificationDetails {
-  implicit val readLocalDateTimeFromString: Reads[ZonedDateTime] = implicitly[Reads[LocalDateTime]]
-    .map(ZonedDateTime.of(_, ZoneId.of("UTC")))
-
-  implicit val writes: OWrites[NotificationDetails] = Json.writes[NotificationDetails]
-  implicit val reads: Reads[NotificationDetails] =
-    ((__ \ "mrn").read[String] and
-      ((__ \ "dateTimeIssued").read[ZonedDateTime] or (__ \ "dateTimeIssued").read[ZonedDateTime](readLocalDateTimeFromString)) and
-      (__ \ "status").read[SubmissionStatus] and
-      (__ \ "errors").read[Seq[NotificationError]])(NotificationDetails.apply _)
-
-  implicit val format: Format[NotificationDetails] = Format(reads, writes)
-}
+import scala.xml.NodeSeq
 
 case class Notification(actionId: String, payload: String, details: Option[NotificationDetails])
 
 object Notification {
+
+  def unparsed(actionId: String, notificationXml: NodeSeq): Notification =
+    Notification(actionId = actionId, payload = notificationXml.toString, details = None)
 
   object DbFormat {
     implicit val writes: Writes[Notification] =

--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/NotificationDetails.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/NotificationDetails.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.models.declaration.notifications
+
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.SubmissionStatus
+
+case class NotificationDetails(mrn: String, dateTimeIssued: ZonedDateTime, status: SubmissionStatus, errors: Seq[NotificationError])
+
+object NotificationDetails {
+  implicit val readLocalDateTimeFromString: Reads[ZonedDateTime] = implicitly[Reads[LocalDateTime]]
+    .map(ZonedDateTime.of(_, ZoneId.of("UTC")))
+
+  implicit val writes: OWrites[NotificationDetails] = Json.writes[NotificationDetails]
+  implicit val reads: Reads[NotificationDetails] =
+    ((__ \ "mrn").read[String] and
+      ((__ \ "dateTimeIssued").read[ZonedDateTime] or (__ \ "dateTimeIssued").read[ZonedDateTime](readLocalDateTimeFromString)) and
+      (__ \ "status").read[SubmissionStatus] and
+      (__ \ "errors").read[Seq[NotificationError]])(NotificationDetails.apply _)
+
+  implicit val format: Format[NotificationDetails] = Format(reads, writes)
+}

--- a/app/uk/gov/hmrc/exports/services/email/EmailSender.scala
+++ b/app/uk/gov/hmrc/exports/services/email/EmailSender.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.email
+
+import javax.inject.{Inject, Singleton}
+import play.api.Logging
+import uk.gov.hmrc.exports.connectors.{CustomsDataStoreConnector, EmailConnector}
+import uk.gov.hmrc.exports.models.declaration.notifications.Notification
+import uk.gov.hmrc.exports.models.emails.SendEmailResult.{BadEmailRequest, EmailAccepted, InternalEmailServiceError}
+import uk.gov.hmrc.exports.models.emails._
+import uk.gov.hmrc.exports.repositories.SubmissionRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class EmailSender @Inject()(
+  submissionRepository: SubmissionRepository,
+  customsDataStoreConnector: CustomsDataStoreConnector,
+  emailConnector: EmailConnector
+)(implicit executionContext: ExecutionContext)
+    extends Logging {
+
+  def sendEmailForDmsDocNotification(notification: Notification)(implicit hc: HeaderCarrier): Future[Unit] = {
+    val mrn = getMrn(notification)
+
+    obtainEori(mrn).map {
+      case Some(eori) =>
+        obtainEmailAddress(eori).map {
+          case Some(verifiedEmailAddress) => sendEmail(mrn, eori, verifiedEmailAddress)
+          case None                       => logEmailAddressNotFound(eori)
+        }
+      case None => ()
+    }
+  }
+
+  private def getMrn(notification: Notification): String = notification.details.map(_.mrn) match {
+    case Some(mrn) => mrn
+    case None =>
+      logger.warn(s"Notification with actionId: ${notification.actionId} does not contain MRN")
+      throw new IllegalArgumentException(s"MRN not found in Notification with actionId: ${notification.actionId}")
+  }
+
+  private def obtainEori(mrn: String): Future[Option[String]] =
+    submissionRepository.findSubmissionByMrn(mrn).map(_.map(_.eori))
+
+  private def obtainEmailAddress(eori: String)(implicit hc: HeaderCarrier): Future[Option[VerifiedEmailAddress]] =
+    customsDataStoreConnector.getEmailAddress(eori)
+
+  private def sendEmail(mrn: String, eori: String, verifiedEmailAddress: VerifiedEmailAddress)(implicit hc: HeaderCarrier): Future[Unit] = {
+    val emailParameters = EmailParameters(Map(EmailParameter.MRN -> mrn))
+    val sendEmailRequest = SendEmailRequest(List(verifiedEmailAddress.address), TemplateId.DMSDOC_NOTIFICATION, emailParameters)
+
+    emailConnector.sendEmail(sendEmailRequest).map {
+      case EmailAccepted                      =>
+      case BadEmailRequest(message)           => logSendEmailError("Bad request", message, eori, mrn)
+      case InternalEmailServiceError(message) => logSendEmailError("Email service error", message, eori, mrn)
+    }
+  }
+
+  private def logEmailAddressNotFound(eori: String): Unit =
+    logger.warn(s"Email address for eori($eori) was not found or it is not verified yet")
+
+  private def logSendEmailError(error: String, message: String, eori: String, mrn: String): Unit =
+    logger.warn(s"$error for eori($eori) and mrn($mrn) while sending a DmsDoc notification email, error was $message")
+
+}

--- a/app/uk/gov/hmrc/exports/services/notifications/NotificationService.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/NotificationService.scala
@@ -66,7 +66,7 @@ class NotificationService @Inject()(
     }
 
   def handleNewNotification(actionId: String, notificationXml: NodeSeq)(implicit hc: HeaderCarrier): Future[Unit] = {
-    val notification = notificationFactory.buildNotificationUnparsed(actionId, notificationXml)
+    val notification = Notification.unparsed(actionId, notificationXml)
 
     notificationRepository.insert(notification).map { _ =>
       notificationReceiptActionsExecutor.executeActions(notification)

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutor.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutor.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.notifications.receiptactions
+
+import java.util.concurrent.TimeUnit.SECONDS
+
+import akka.actor.{ActorSystem, Cancellable}
+import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.exports.models.declaration.notifications.Notification
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.FiniteDuration
+
+@Singleton
+class NotificationReceiptActionsExecutor @Inject()(
+  actorSystem: ActorSystem,
+  parseAndSaveAction: ParseAndSaveAction,
+  sendEmailForDmsDocAction: SendEmailForDmsDocAction
+)(implicit executionContext: ExecutionContext) {
+
+  def executeActions(notification: Notification)(implicit hc: HeaderCarrier): Cancellable =
+    actorSystem.scheduler.scheduleOnce(FiniteDuration(0, SECONDS)) {
+      for {
+        _ <- parseAndSaveAction.execute(notification)
+        _ <- sendEmailForDmsDocAction.execute(notification)
+      } yield ()
+    }
+
+}

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutor.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutor.scala
@@ -37,7 +37,7 @@ class NotificationReceiptActionsExecutor @Inject()(
     actorSystem.scheduler.scheduleOnce(FiniteDuration(0, SECONDS)) {
       for {
         _ <- parseAndSaveAction.execute(notification)
-        _ <- sendEmailForDmsDocAction.execute(notification)
+        _ <- sendEmailForDmsDocAction.execute(notification.actionId)
       } yield ()
     }
 

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveAction.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveAction.scala
@@ -32,9 +32,9 @@ class ParseAndSaveAction @Inject()(
   notificationRepository: NotificationRepository,
   notificationFactory: NotificationFactory
 )(implicit executionContext: ExecutionContext)
-    extends NotificationReceiptAction with Logging {
+    extends Logging {
 
-  override def execute(notification: Notification): Future[Unit] = {
+  def execute(notification: Notification): Future[Unit] = {
     val parsedNotifications = notificationFactory
       .buildNotifications(notification.actionId, notification.payload)
       .filter(_.details.nonEmpty)
@@ -53,7 +53,7 @@ class ParseAndSaveAction @Inject()(
         for {
           _ <- notificationRepository.insert(notification)
           _ <- updateRelatedSubmission(notification)
-        } yield (())
+        } yield ()
       })
       .map(_ => ())
 

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocAction.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocAction.scala
@@ -15,11 +15,22 @@
  */
 
 package uk.gov.hmrc.exports.services.notifications.receiptactions
-
+import javax.inject.{Inject, Singleton}
+import play.api.Logging
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
+import uk.gov.hmrc.exports.services.email.EmailSender
+import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.Future
 
-trait NotificationReceiptAction {
-  def execute(notification: Notification): Future[Unit]
+@Singleton
+class SendEmailForDmsDocAction @Inject()(emailSender: EmailSender) extends Logging {
+
+  def execute(notification: Notification)(implicit hc: HeaderCarrier): Future[Unit] =
+    if (notification.details.get.status == SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED)
+      emailSender.sendEmailForDmsDocNotification(notification)
+    else
+      Future.successful((): Unit)
+
 }

--- a/test/unit/uk/gov/hmrc/exports/base/UnitSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/UnitSpec.scala
@@ -22,4 +22,8 @@ import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, OptionValues}
 
-trait UnitSpec extends AnyWordSpec with BeforeAndAfterAll with BeforeAndAfterEach with Matchers with MockitoSugar with OptionValues with ScalaFutures
+trait UnitSpec
+    extends AnyWordSpec with BeforeAndAfterAll with BeforeAndAfterEach with Matchers with MockitoSugar with OptionValues with ScalaFutures {
+
+  val unit: Unit = (): Unit
+}

--- a/test/unit/uk/gov/hmrc/exports/controllers/NotificationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/controllers/NotificationControllerSpec.scala
@@ -16,10 +16,6 @@
 
 package uk.gov.hmrc.exports.controllers
 
-import scala.concurrent.Future
-import scala.util.Random
-import scala.xml.{Elem, NodeSeq}
-
 import com.codahale.metrics.SharedMetricRegistries
 import org.joda.time.{DateTime, DateTimeZone}
 import org.mockito.ArgumentMatchers.{any, anyString}
@@ -41,7 +37,12 @@ import uk.gov.hmrc.exports.base.{AuthTestSupport, UnitSpec}
 import uk.gov.hmrc.exports.models.declaration.notifications.Notification
 import uk.gov.hmrc.exports.services.SubmissionService
 import uk.gov.hmrc.exports.services.notifications.NotificationService
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.wco.dec.{DateTimeString, Response, ResponseDateTimeElement}
+
+import scala.concurrent.Future
+import scala.util.Random
+import scala.xml.{Elem, NodeSeq}
 
 class NotificationControllerSpec extends UnitSpec with GuiceOneAppPerSuite with AuthTestSupport {
 
@@ -198,7 +199,7 @@ class NotificationControllerSpec extends UnitSpec with GuiceOneAppPerSuite with 
     "everything works correctly" should {
 
       "return Accepted status" in {
-        when(notificationService.handleNewNotification(anyString(), any[NodeSeq])).thenReturn(Future.successful((): Unit))
+        when(notificationService.handleNewNotification(anyString(), any[NodeSeq])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
 
         val result = routePostSaveNotification()
 
@@ -206,18 +207,19 @@ class NotificationControllerSpec extends UnitSpec with GuiceOneAppPerSuite with 
       }
 
       "call NotificationService once" in {
-        when(notificationService.handleNewNotification(anyString(), any[NodeSeq])).thenReturn(Future.successful((): Unit))
+        when(notificationService.handleNewNotification(anyString(), any[NodeSeq])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
 
         routePostSaveNotification().futureValue
 
-        verify(notificationService).handleNewNotification(anyString(), any[NodeSeq])
+        verify(notificationService).handleNewNotification(anyString(), any[NodeSeq])(any[HeaderCarrier])
       }
     }
 
     "NotificationService returns failure" should {
 
       "throw an Exception" in {
-        when(notificationService.handleNewNotification(any(), any[NodeSeq])).thenReturn(Future.failed(new Exception("Test Exception")))
+        when(notificationService.handleNewNotification(any(), any[NodeSeq])(any[HeaderCarrier]))
+          .thenReturn(Future.failed(new Exception("Test Exception")))
 
         an[Exception] mustBe thrownBy {
           routePostSaveNotification().futureValue

--- a/test/unit/uk/gov/hmrc/exports/services/email/EmailSenderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/email/EmailSenderSpec.scala
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.email
+
+import org.mockito.ArgumentMatchers.{any, anyString, eq => eqTo}
+import testdata.notifications.NotificationTestData
+import testdata.{ExportsTestData, SubmissionTestData}
+import uk.gov.hmrc.exports.base.UnitSpec
+import uk.gov.hmrc.exports.connectors.{CustomsDataStoreConnector, EmailConnector}
+import uk.gov.hmrc.exports.models.emails.SendEmailResult.{BadEmailRequest, EmailAccepted, InternalEmailServiceError}
+import uk.gov.hmrc.exports.models.emails._
+import uk.gov.hmrc.exports.repositories.SubmissionRepository
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class EmailSenderSpec extends UnitSpec {
+
+  private implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+  private val submissionRepository = mock[SubmissionRepository]
+  private val customsDataStoreConnector = mock[CustomsDataStoreConnector]
+  private val emailConnector = mock[EmailConnector]
+
+  private val emailSender = new EmailSender(submissionRepository, customsDataStoreConnector, emailConnector)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(submissionRepository, customsDataStoreConnector, emailConnector)
+  }
+
+  override def afterEach(): Unit = {
+    reset(submissionRepository, customsDataStoreConnector, emailConnector)
+    super.afterEach()
+  }
+
+  "EmailSender on sendEmailForDmsDocNotification" when {
+
+    val testSubmission = SubmissionTestData.submission
+    val testVerifiedEmailAddress: VerifiedEmailAddress = ExportsTestData.verifiedEmailAddress
+    val testNotification = NotificationTestData.notification
+
+    "everything works correctly" should {
+
+      "return successful Future" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
+        when(emailConnector.sendEmail(any[SendEmailRequest])(any())).thenReturn(Future.successful(EmailAccepted))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+      }
+
+      "call SubmissionRepository with correct parameters" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
+        when(emailConnector.sendEmail(any[SendEmailRequest])(any())).thenReturn(Future.successful(EmailAccepted))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue
+
+        val expectedMrn = testNotification.details.get.mrn
+        verify(submissionRepository).findSubmissionByMrn(eqTo(expectedMrn))
+      }
+
+      "call CustomsDataStoreConnector with correct parameters" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
+        when(emailConnector.sendEmail(any[SendEmailRequest])(any())).thenReturn(Future.successful(EmailAccepted))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue
+
+        val expectedEori = testSubmission.eori
+        verify(customsDataStoreConnector).getEmailAddress(eqTo(expectedEori))(any[HeaderCarrier])
+      }
+
+      "call EmailConnector with correct parameters" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
+        when(emailConnector.sendEmail(any[SendEmailRequest])(any())).thenReturn(Future.successful(EmailAccepted))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue
+
+        val expectedSendEmailRequest = SendEmailRequest(
+          List(testVerifiedEmailAddress.address),
+          TemplateId.DMSDOC_NOTIFICATION,
+          EmailParameters(Map(EmailParameter.MRN -> testNotification.details.get.mrn))
+        )
+        verify(emailConnector).sendEmail(eqTo(expectedSendEmailRequest))(any[HeaderCarrier])
+      }
+    }
+
+    "provided with Notification with empty details" should {
+
+      "throw IllegalArgumentException" in {
+
+        val expectedEXceptionMessage = s"MRN not found in Notification with actionId: ${testNotification.actionId}"
+
+        the[IllegalArgumentException] thrownBy {
+          emailSender.sendEmailForDmsDocNotification(testNotification.copy(details = None)).failed.futureValue
+        } must have message expectedEXceptionMessage
+      }
+    }
+
+    "SubmissionRepository returns empty Option" should {
+
+      "return successful Future" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(None))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+      }
+
+      "not call CustomsDataStoreConnector" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(None))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue
+
+        verifyZeroInteractions(customsDataStoreConnector)
+      }
+
+      "not call EmailConnector" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(None))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue
+
+        verifyZeroInteractions(emailConnector)
+      }
+    }
+
+    "CustomsDataStoreConnector returns empty Option" should {
+
+      "return successful Future" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(None))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+      }
+
+      "not call EmailConnector" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(None))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue
+
+        verifyZeroInteractions(emailConnector)
+      }
+    }
+
+    "EmailConnector returns BadEmailRequest" should {
+
+      "return successful Future" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
+        when(emailConnector.sendEmail(any[SendEmailRequest])(any())).thenReturn(Future.successful(BadEmailRequest("Test BadEmailRequest message")))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+      }
+    }
+
+    "EmailConnector returns InternalEmailServiceError" should {
+
+      "return successful Future" in {
+        when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
+        when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
+        when(emailConnector.sendEmail(any[SendEmailRequest])(any()))
+          .thenReturn(Future.successful(InternalEmailServiceError("Test InternalEmailServiceError message")))
+
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+      }
+    }
+  }
+
+}

--- a/test/unit/uk/gov/hmrc/exports/services/email/EmailSenderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/email/EmailSenderSpec.scala
@@ -62,7 +62,7 @@ class EmailSenderSpec extends UnitSpec {
         when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
         when(emailConnector.sendEmail(any[SendEmailRequest])(any())).thenReturn(Future.successful(EmailAccepted))
 
-        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe unit
       }
 
       "call SubmissionRepository with correct parameters" in {
@@ -120,7 +120,7 @@ class EmailSenderSpec extends UnitSpec {
       "return successful Future" in {
         when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(None))
 
-        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe unit
       }
 
       "not call CustomsDataStoreConnector" in {
@@ -146,7 +146,7 @@ class EmailSenderSpec extends UnitSpec {
         when(submissionRepository.findSubmissionByMrn(anyString())).thenReturn(Future.successful(Some(testSubmission)))
         when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(None))
 
-        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe unit
       }
 
       "not call EmailConnector" in {
@@ -166,7 +166,7 @@ class EmailSenderSpec extends UnitSpec {
         when(customsDataStoreConnector.getEmailAddress(anyString())(any())).thenReturn(Future.successful(Some(testVerifiedEmailAddress)))
         when(emailConnector.sendEmail(any[SendEmailRequest])(any())).thenReturn(Future.successful(BadEmailRequest("Test BadEmailRequest message")))
 
-        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe unit
       }
     }
 
@@ -178,7 +178,7 @@ class EmailSenderSpec extends UnitSpec {
         when(emailConnector.sendEmail(any[SendEmailRequest])(any()))
           .thenReturn(Future.successful(InternalEmailServiceError("Test InternalEmailServiceError message")))
 
-        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe ()
+        emailSender.sendEmailForDmsDocNotification(testNotification).futureValue mustBe unit
       }
     }
   }

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationFactorySpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationFactorySpec.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.exports.services.notifications
 
-import scala.xml.NodeSeq
-
 import org.mockito.ArgumentMatchers.{any, eq => meq}
 import testdata.ExportsTestData.{actionId, mrn}
 import testdata.notifications.ExampleXmlAndNotificationDetailsPair._
 import testdata.notifications.NotificationTestData._
 import uk.gov.hmrc.exports.base.UnitSpec
+
+import scala.xml.NodeSeq
 
 class NotificationFactorySpec extends UnitSpec {
 
@@ -179,58 +179,14 @@ class NotificationFactorySpec extends UnitSpec {
         noException should be thrownBy notificationFactory.buildNotifications(actionId, xmlInput)
       }
 
-      "return single Notification with actionId" in {
+      "return empty sequence" in {
         when(notificationParser.parse(any[NodeSeq])).thenThrow(exception)
 
         val result = notificationFactory.buildNotifications(actionId, xmlInput)
 
-        result.size mustBe 1
-        result.head.actionId mustBe actionId
-      }
-
-      "return single Notification with payload" in {
-        when(notificationParser.parse(any[NodeSeq])).thenThrow(exception)
-
-        val result = notificationFactory.buildNotifications(actionId, xmlInput)
-
-        result.size mustBe 1
-        result.head.payload mustBe xmlInput
-      }
-
-      "return single Notification with empty details" in {
-        when(notificationParser.parse(any[NodeSeq])).thenThrow(exception)
-
-        val result = notificationFactory.buildNotifications(actionId, xmlInput)
-
-        result.size mustBe 1
-        result.head.details mustBe empty
+        result mustBe empty
       }
     }
   }
 
-  "NotificationFactory on buildNotificationUnparsed" should {
-
-    val xml = exampleReceivedNotification(mrn).asXml
-
-    "return Notification with actionId" in {
-
-      val result = notificationFactory.buildNotificationUnparsed(actionId, xml)
-
-      result.actionId mustBe actionId
-    }
-
-    "return Notification with payload" in {
-
-      val result = notificationFactory.buildNotificationUnparsed(actionId, xml)
-
-      result.payload mustBe xml.toString
-    }
-
-    "return Notification with empty details" in {
-
-      val result = notificationFactory.buildNotificationUnparsed(actionId, xml)
-
-      result.details mustBe empty
-    }
-  }
 }

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
@@ -38,7 +38,6 @@ import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
-import scala.xml.NodeSeq
 
 class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
 
@@ -63,7 +62,6 @@ class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
     reset(submissionRepository, notificationRepository, notificationFactory, parseAndSaveAction, notificationReceiptActionsExecutor)
 
     when(notificationFactory.buildNotifications(any, any)).thenReturn(Seq(notification))
-    when(notificationFactory.buildNotificationUnparsed(any, any[NodeSeq])).thenReturn(notification.copy(details = None))
     when(notificationRepository.insert(any)(any)).thenReturn(Future.successful(dummyWriteResultSuccess))
     when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(submission)))
     when(parseAndSaveAction.execute(any[Notification])).thenReturn(Future.successful((): Unit))
@@ -176,16 +174,7 @@ class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
       val inputXml = exampleReceivedNotification(mrn).asXml
       val testNotificationUnparsed = Notification(actionId = actionId, payload = inputXml.toString, details = None)
 
-      "call NotificationFactory" in {
-        when(notificationFactory.buildNotificationUnparsed(any[String], any[NodeSeq])).thenReturn(testNotificationUnparsed)
-
-        notificationService.handleNewNotification(actionId, inputXml).futureValue
-
-        verify(notificationFactory).buildNotificationUnparsed(eqTo(actionId), eqTo(inputXml))
-      }
-
       "call NotificationRepository" in {
-        when(notificationFactory.buildNotificationUnparsed(any[String], any[NodeSeq])).thenReturn(testNotificationUnparsed)
 
         notificationService.handleNewNotification(actionId, inputXml).futureValue
 
@@ -193,7 +182,6 @@ class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
       }
 
       "call NotificationReceiptActionsExecutor" in {
-        when(notificationFactory.buildNotificationUnparsed(any[String], any[NodeSeq])).thenReturn(testNotificationUnparsed)
 
         notificationService.handleNewNotification(actionId, inputXml).futureValue
 

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutorSpec.scala
@@ -60,7 +60,7 @@ class NotificationReceiptActionsExecutorSpec extends UnitSpec {
 
       "call scheduler with zero delay" in {
         when(parseAndSaveAction.execute(any[Notification])).thenReturn(Future.successful((): Unit))
-        when(sendEmailForDmsDocAction.execute(any[Notification])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
+        when(sendEmailForDmsDocAction.execute(any[String])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
 
         notificationReceiptActionsExecutor.executeActions(notification)
 
@@ -70,13 +70,13 @@ class NotificationReceiptActionsExecutorSpec extends UnitSpec {
 
       "call actions in order" in {
         when(parseAndSaveAction.execute(any[Notification])).thenReturn(Future.successful((): Unit))
-        when(sendEmailForDmsDocAction.execute(any[Notification])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
+        when(sendEmailForDmsDocAction.execute(any[String])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
 
         notificationReceiptActionsExecutor.executeActions(notification)
 
         val inOrder = Mockito.inOrder(parseAndSaveAction, sendEmailForDmsDocAction)
         inOrder.verify(parseAndSaveAction).execute(eqTo(notification))
-        inOrder.verify(sendEmailForDmsDocAction).execute(eqTo(notification))(any[HeaderCarrier])
+        inOrder.verify(sendEmailForDmsDocAction).execute(eqTo(notification.actionId))(any[HeaderCarrier])
       }
     }
 

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsExecutorSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.notifications.receiptactions
+
+import java.util.concurrent.TimeUnit.SECONDS
+
+import akka.actor.{ActorSystem, Cancellable, Scheduler}
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import org.mockito.Mockito
+import testdata.notifications.NotificationTestData.notification
+import uk.gov.hmrc.exports.base.UnitSpec
+import uk.gov.hmrc.exports.models.declaration.notifications.Notification
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration.FiniteDuration
+
+class NotificationReceiptActionsExecutorSpec extends UnitSpec {
+
+  private implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+
+  private val actorSystem: ActorSystem = mock[ActorSystem]
+  private val scheduler: Scheduler = mock[Scheduler]
+  private val parseAndSaveAction: ParseAndSaveAction = mock[ParseAndSaveAction]
+  private val sendEmailForDmsDocAction: SendEmailForDmsDocAction = mock[SendEmailForDmsDocAction]
+
+  private val notificationReceiptActionsExecutor = new NotificationReceiptActionsExecutor(actorSystem, parseAndSaveAction, sendEmailForDmsDocAction)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(actorSystem, scheduler, parseAndSaveAction, sendEmailForDmsDocAction)
+    when(actorSystem.scheduler).thenReturn(scheduler)
+    when(scheduler.scheduleOnce(any)(any[() => Unit])(any)).thenReturn(Cancellable.alreadyCancelled)
+  }
+
+  override def afterEach(): Unit = {
+    reset(actorSystem, scheduler, parseAndSaveAction, sendEmailForDmsDocAction)
+    super.afterEach()
+  }
+
+  "NotificationReceiptActionsExecutor on executeActions" when {
+
+    "all actions work correctly" should {
+
+      "call scheduler with zero delay" in {
+        when(parseAndSaveAction.execute(any[Notification])).thenReturn(Future.successful((): Unit))
+        when(sendEmailForDmsDocAction.execute(any[Notification])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
+
+        notificationReceiptActionsExecutor.executeActions(notification)
+
+        val expectedDelay = FiniteDuration(0, SECONDS)
+        verify(scheduler).scheduleOnce(eqTo(expectedDelay))(any[() => Unit])(any)
+      }
+
+      "call actions in order" in {
+        when(parseAndSaveAction.execute(any[Notification])).thenReturn(Future.successful((): Unit))
+        when(sendEmailForDmsDocAction.execute(any[Notification])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
+
+        notificationReceiptActionsExecutor.executeActions(notification)
+
+        val inOrder = Mockito.inOrder(parseAndSaveAction, sendEmailForDmsDocAction)
+        inOrder.verify(parseAndSaveAction).execute(eqTo(notification))
+        inOrder.verify(sendEmailForDmsDocAction).execute(eqTo(notification))(any[HeaderCarrier])
+      }
+    }
+
+    "ParseAndSaveAction returns failed Future" should {
+
+      "call scheduler with zero delay" in {
+        val testException = new RuntimeException("Test exception message")
+        when(parseAndSaveAction.execute(any[Notification])).thenReturn(Future.failed(testException))
+
+        notificationReceiptActionsExecutor.executeActions(notification)
+
+        val expectedDelay = FiniteDuration(0, SECONDS)
+        verify(scheduler).scheduleOnce(eqTo(expectedDelay))(any[() => Unit])(any)
+      }
+
+      "not call SendEmailForDmsDocAction" in {
+        val testException = new RuntimeException("Test exception message")
+        when(parseAndSaveAction.execute(any[Notification])).thenReturn(Future.failed(testException))
+
+        notificationReceiptActionsExecutor.executeActions(notification)
+
+        verifyZeroInteractions(sendEmailForDmsDocAction)
+      }
+    }
+  }
+
+}

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocActionSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocActionSpec.scala
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.notifications.receiptactions
+
+import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import testdata.notifications.NotificationTestData.notification
+import uk.gov.hmrc.exports.base.UnitSpec
+import uk.gov.hmrc.exports.models.declaration.notifications.Notification
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
+import uk.gov.hmrc.exports.services.email.EmailSender
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.Future
+
+class SendEmailForDmsDocActionSpec extends UnitSpec {
+
+  private implicit val hc: HeaderCarrier = mock[HeaderCarrier]
+  private val emailSender = mock[EmailSender]
+
+  private val sendEmailForDmsDocAction = new SendEmailForDmsDocAction(emailSender)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(emailSender)
+  }
+
+  override def afterEach(): Unit = {
+    reset(emailSender)
+    super.afterEach()
+  }
+
+  "SendEmailForDmsDocAction on execute" when {
+
+    "provided with Notification with status ADDITIONAL_DOCUMENTS_REQUIRED" when {
+
+      val testNotification = notification.copy(details = notification.details.map(_.copy(status = SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED)))
+
+      "EmailSender returns successful Future" should {
+
+        "return successful Future" in {
+          when(emailSender.sendEmailForDmsDocNotification(any[Notification])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
+
+          sendEmailForDmsDocAction.execute(testNotification).futureValue mustBe unit
+        }
+
+        "call EmailSender" in {
+          when(emailSender.sendEmailForDmsDocNotification(any[Notification])(any[HeaderCarrier])).thenReturn(Future.successful((): Unit))
+
+          sendEmailForDmsDocAction.execute(testNotification).futureValue
+
+          verify(emailSender).sendEmailForDmsDocNotification(eqTo(testNotification))(any[HeaderCarrier])
+        }
+      }
+
+      "EmailSender throws an Exception" should {
+
+        "propagate this exception" in {
+          val exceptionMsg = "Test exception message"
+          when(emailSender.sendEmailForDmsDocNotification(any[Notification])(any[HeaderCarrier])).thenThrow(new RuntimeException(exceptionMsg))
+
+          the[RuntimeException] thrownBy {
+            sendEmailForDmsDocAction.execute(testNotification).failed.futureValue
+          } must have message exceptionMsg
+        }
+      }
+    }
+
+    "provided with Notification with status not equal to ADDITIONAL_DOCUMENTS_REQUIRED" should {
+
+      val testNotification = notification
+
+      "return successful Future" in {
+
+        sendEmailForDmsDocAction.execute(testNotification).futureValue mustBe unit
+      }
+
+      "not call EmailSender" in {
+
+        sendEmailForDmsDocAction.execute(testNotification).futureValue
+
+        verifyZeroInteractions(emailSender)
+      }
+    }
+  }
+
+}

--- a/test/util/testdata/ExportsTestData.scala
+++ b/test/util/testdata/ExportsTestData.scala
@@ -16,14 +16,17 @@
 
 package testdata
 
+import java.time.ZonedDateTime
+
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{DateTime, DateTimeZone}
 import play.api.http.HeaderNames.CONTENT_TYPE
 import play.api.http.{ContentTypes, HeaderNames}
+import testdata.TestDataHelper.randomAlphanumericString
 import uk.gov.hmrc.exports.controllers.util.CustomsHeaderNames._
 import uk.gov.hmrc.exports.models.Eori
+import uk.gov.hmrc.exports.models.emails.VerifiedEmailAddress
 import uk.gov.hmrc.wco.dec.{DateTimeString, MetaData, ResponseDateTimeElement, Declaration => WcoDeclaration}
-import testdata.TestDataHelper.randomAlphanumericString
 
 object ExportsTestData {
 
@@ -54,6 +57,8 @@ object ExportsTestData {
   val VALID_DUCR_HEADER: (String, String) = XDucrHeaderName -> declarantDucrValue
   val VALID_MRN_HEADER: (String, String) = XMrnHeaderName -> declarantMrnValue
   val now: DateTime = DateTime.now.withZone(DateTimeZone.UTC)
+
+  val verifiedEmailAddress = VerifiedEmailAddress("some@email.com", ZonedDateTime.now)
 
   val dtfOut = DateTimeFormat.forPattern("yyyyMMddHHmmss")
   def dateTimeElement(dateTimeVal: DateTime) =


### PR DESCRIPTION
This PR implements logic necessary to obtain required data
and sending request to `email` service.
Additionally, it also integrates this process into Notification
processing "pipeline" as an action executed after successful
parsing, saving and MRN update to the related Submission.

This operation is implemented in a way that it is completely
independent from any other process.

Majority of the email sending logic was created by @udinobi .