### PR TITLE
CEDS-3045 Pager Duty alert triggering when failing to send email

### DIFF
--- a/app/uk/gov/hmrc/exports/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/exports/config/AppConfig.scala
@@ -69,6 +69,8 @@ class AppConfig @Inject()(val configuration: Configuration, val environment: Env
   lazy val sendEmailsJobInterval: FiniteDuration = servicesConfig.getDuration("scheduler.send-emails.interval").asInstanceOf[FiniteDuration]
   lazy val consideredFailedBeforeWorkItem: FiniteDuration =
     servicesConfig.getDuration("workItem.sendEmail.consideredFailedBefore").asInstanceOf[FiniteDuration]
+  lazy val sendEmailPagerDutyAlertTriggerDelay: FiniteDuration =
+    servicesConfig.getDuration("workItem.sendEmail.pagerDutyAlertTriggerDelay").asInstanceOf[FiniteDuration]
 
   lazy val customsDeclarationsInformationBaseUrl = servicesConfig.baseUrl("customs-declarations-information")
   lazy val fetchMrnStatus = servicesConfig.getString("microservice.services.customs-declarations-information.fetch-mrn-status")

--- a/app/uk/gov/hmrc/exports/scheduler/ScheduledJobModule.scala
+++ b/app/uk/gov/hmrc/exports/scheduler/ScheduledJobModule.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.exports.scheduler
 import javax.inject.{Inject, Provider}
 import play.api.inject._
 import play.api.{Configuration, Environment}
-import uk.gov.hmrc.exports.scheduler.jobs.{PurgeDraftDeclarationsJob, SendEmailsJob}
+import uk.gov.hmrc.exports.scheduler.jobs.PurgeDraftDeclarationsJob
+import uk.gov.hmrc.exports.scheduler.jobs.emails.SendEmailsJob
 
 class ScheduledJobModule extends play.api.inject.Module {
   override def bindings(environment: Environment, configuration: Configuration): Seq[Binding[_]] =

--- a/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertManager.scala
+++ b/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertManager.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.scheduler.jobs.emails
+
+import javax.inject.Inject
+import uk.gov.hmrc.exports.config.AppConfig
+import uk.gov.hmrc.exports.models.emails.SendEmailDetails
+import uk.gov.hmrc.workitem.{Failed, WorkItem}
+
+class PagerDutyAlertManager @Inject()(appConfig: AppConfig) {
+
+  def isPagerDutyAlertRequiredFor(workItem: WorkItem[SendEmailDetails]): Boolean = {
+    val isStatusFailed = workItem.status == Failed
+    val isAlertNotTriggered = !workItem.item.alertTriggered
+
+    val workItemMaturity = appConfig.sendEmailPagerDutyAlertTriggerDelay
+    val isWorkItemOld = workItem.receivedAt.plus(workItemMaturity.toMillis).isBeforeNow
+
+    isStatusFailed && isAlertNotTriggered && isWorkItemOld
+  }
+}

--- a/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertManager.scala
+++ b/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertManager.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.exports.scheduler.jobs.emails
 
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import play.api.Logging
 import reactivemongo.api.ReadPreference
 import reactivemongo.bson.BSONObjectID
@@ -27,6 +27,7 @@ import uk.gov.hmrc.workitem.WorkItem
 
 import scala.concurrent.{ExecutionContext, Future}
 
+@Singleton
 class PagerDutyAlertManager @Inject()(
   appConfig: AppConfig,
   sendEmailWorkItemRepository: SendEmailWorkItemRepository,

--- a/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidator.scala
+++ b/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidator.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.scheduler.jobs.emails
+
+import javax.inject.Inject
+import play.api.Logging
+import uk.gov.hmrc.exports.config.AppConfig
+import uk.gov.hmrc.exports.models.emails.SendEmailDetails
+import uk.gov.hmrc.workitem.{Failed, WorkItem}
+
+class PagerDutyAlertValidator @Inject()(appConfig: AppConfig) extends Logging {
+
+  def isPagerDutyAlertRequiredFor(workItem: WorkItem[SendEmailDetails]): Boolean = {
+    val isStatusFailed = workItem.status == Failed
+    val isAlertNotTriggered = !workItem.item.alertTriggered
+
+    val workItemMaturity = appConfig.sendEmailPagerDutyAlertTriggerDelay
+    val isWorkItemOld = workItem.receivedAt.plus(workItemMaturity.toMillis).isBeforeNow
+
+    isStatusFailed && isAlertNotTriggered && isWorkItemOld
+  }
+
+}

--- a/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidator.scala
+++ b/app/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidator.scala
@@ -17,12 +17,11 @@
 package uk.gov.hmrc.exports.scheduler.jobs.emails
 
 import javax.inject.Inject
-import play.api.Logging
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.exports.models.emails.SendEmailDetails
 import uk.gov.hmrc.workitem.{Failed, WorkItem}
 
-class PagerDutyAlertValidator @Inject()(appConfig: AppConfig) extends Logging {
+class PagerDutyAlertValidator @Inject()(appConfig: AppConfig) {
 
   def isPagerDutyAlertRequiredFor(workItem: WorkItem[SendEmailDetails]): Boolean = {
     val isStatusFailed = workItem.status == Failed

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -237,4 +237,5 @@ contexts {
 workItem.sendEmail {
     retryAfterMillis = 300000
     consideredFailedBefore = "4m"
+    pagerDutyAlertTriggerDelay = "1d"
 }

--- a/test/it/uk/gov/hmrc/exports/repositories/SendEmailWorkItemRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/exports/repositories/SendEmailWorkItemRepositorySpec.scala
@@ -170,4 +170,33 @@ class SendEmailWorkItemRepositorySpec extends IntegrationTestBaseSpec {
     }
   }
 
+  "SendEmailWorkItemRepository on updateAlertTriggered" when {
+
+    "provided with existing ID parameter" should {
+
+      "update the document's alertTriggered field" in {
+
+        val workItem = buildTestWorkItem(Failed)
+        repo.insert(workItem).futureValue.ok mustBe true
+
+        val result = repo.markAlertTriggered(workItem.id).futureValue
+
+        result mustBe defined
+        result.get.item.alertTriggered mustBe true
+      }
+    }
+
+    "provided with non-existing ID parameter" should {
+
+      "not upsert any document" in {
+
+        val workItem = buildTestWorkItem(Failed)
+        repo.insert(workItem).futureValue.ok mustBe true
+
+        val result = repo.markAlertTriggered(BSONObjectID.generate()).futureValue
+
+        result mustNot be(defined)
+      }
+    }
+  }
 }

--- a/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
@@ -20,12 +20,14 @@ import java.time.LocalTime
 
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.must.Matchers
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import uk.gov.hmrc.exports.config.AppConfig.JobConfig
 
 import scala.concurrent.duration._
 
-class AppConfigSpec extends AnyFunSuite with Matchers {
+class AppConfigSpec extends AnyFunSuite with Matchers with GuiceOneAppPerSuite {
 
   val mongodbUri = "mongodb://localhost:27017/customs-declare-exports"
   val authUrl = "http://localhost:8500"
@@ -51,7 +53,8 @@ class AppConfigSpec extends AnyFunSuite with Matchers {
   val emailServiceBaseUrl = "http://localhost:8300"
   val sendEmailPath = "/hmrc/email"
 
-  private val appConfig = GuiceApplicationBuilder().injector.instanceOf[AppConfig]
+  override lazy val app: Application = GuiceApplicationBuilder().build()
+  private val appConfig = app.injector.instanceOf[AppConfig]
 
   test(s"mongodbUri must be $mongodbUri") { appConfig.mongodbUri mustBe mongodbUri }
 

--- a/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
@@ -39,6 +39,7 @@ class AppConfigSpec extends AnyFunSuite with Matchers {
   val draftTimeToLive: FiniteDuration = 30.days
   val purgeDraftDeclarations = JobConfig(LocalTime.of(23, 30), 1.day)
   val sendEmailsJobInterval: FiniteDuration = 5.minutes
+  val sendEmailPagerDutyAlertTriggerDelay: FiniteDuration = 1.day
   val consideredFailedBeforeWorkItem: FiniteDuration = 4.minutes
   val customsDeclarationsInformationBaseUrl = "http://localhost:9834"
   val fetchMrnStatus = "/mrn/ID/status"
@@ -87,6 +88,10 @@ class AppConfigSpec extends AnyFunSuite with Matchers {
 
   test(s"consideredFailedBeforeWorkItem must be $consideredFailedBeforeWorkItem") {
     appConfig.consideredFailedBeforeWorkItem mustBe consideredFailedBeforeWorkItem
+  }
+
+  test(s"sendEmailPagerDutyAlertTriggerDelay must be $sendEmailPagerDutyAlertTriggerDelay") {
+    appConfig.sendEmailPagerDutyAlertTriggerDelay mustBe sendEmailPagerDutyAlertTriggerDelay
   }
 
   test(s"customsDeclarationsInformationBaseUrl must be $customsDeclarationsInformationBaseUrl") {

--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertManagerSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertManagerSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.scheduler.jobs.emails
+
+import org.joda.time.DateTime.now
+import reactivemongo.bson.BSONObjectID
+import testdata.ExportsTestData
+import uk.gov.hmrc.exports.base.UnitSpec
+import uk.gov.hmrc.exports.config.AppConfig
+import uk.gov.hmrc.exports.models.emails.SendEmailDetails
+import uk.gov.hmrc.exports.scheduler.jobs.emails.PagerDutyAlertManagerSpec.TestDefinition
+import uk.gov.hmrc.workitem.{Failed, ProcessingStatus, ToDo, WorkItem}
+
+import scala.concurrent.duration._
+
+class PagerDutyAlertManagerSpec extends UnitSpec {
+
+  private val appConfig = mock[AppConfig]
+  private val testAlertTriggerDelay = 1.day
+
+  private val pagerDutyAlertManager = new PagerDutyAlertManager(appConfig)
+
+  private val testDefinitions = Seq(
+    TestDefinition(workItemStatus = ToDo, alertTriggered = false, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = true, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = testAlertTriggerDelay, expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = true),
+    TestDefinition(workItemStatus = Failed, alertTriggered = true, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false)
+  )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(appConfig)
+    when(appConfig.sendEmailPagerDutyAlertTriggerDelay).thenReturn(testAlertTriggerDelay)
+  }
+
+  "PagerDutyAlertManager on isPagerDutyAlertRequiredFor" when {
+
+    testDefinitions.foreach { testDefinition =>
+      s"WotkItem status is '${testDefinition.workItemStatus}', alertTriggered field equals ${testDefinition.alertTriggered}" +
+        s" and receivedAt field is ${testDefinition.workItemAge} in the past" should {
+        s"return ${testDefinition.expectedResult}" in {
+
+          val receivedAtValue = now.minus(testDefinition.workItemAge.toMillis)
+
+          val testWorkItem = WorkItem[SendEmailDetails](
+            id = BSONObjectID.generate,
+            receivedAt = receivedAtValue,
+            updatedAt = now,
+            availableAt = now,
+            status = testDefinition.workItemStatus,
+            failureCount = 0,
+            item = SendEmailDetails(notificationId = BSONObjectID.generate, mrn = ExportsTestData.mrn, alertTriggered = testDefinition.alertTriggered)
+          )
+
+          pagerDutyAlertManager.isPagerDutyAlertRequiredFor(testWorkItem) mustBe testDefinition.expectedResult
+        }
+      }
+    }
+  }
+
+}
+
+object PagerDutyAlertManagerSpec {
+  private case class TestDefinition(workItemStatus: ProcessingStatus, alertTriggered: Boolean, workItemAge: Duration, expectedResult: Boolean)
+}

--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidatorSpec.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.scheduler.jobs.emails
+
+import org.joda.time.DateTime.now
+import reactivemongo.bson.BSONObjectID
+import testdata.ExportsTestData
+import uk.gov.hmrc.exports.base.UnitSpec
+import uk.gov.hmrc.exports.config.AppConfig
+import uk.gov.hmrc.exports.models.emails.SendEmailDetails
+import uk.gov.hmrc.exports.scheduler.jobs.emails.PagerDutyAlertValidatorSpec.TestDefinition
+import uk.gov.hmrc.workitem.{Failed, ProcessingStatus, ToDo, WorkItem}
+
+import scala.concurrent.duration._
+
+class PagerDutyAlertValidatorSpec extends UnitSpec {
+
+  private val appConfig = mock[AppConfig]
+  private val testAlertTriggerDelay = 1.day
+
+  private val pagerDutyAlertManager = new PagerDutyAlertValidator(appConfig)
+
+  private val testDefinitions = Seq(
+    TestDefinition(workItemStatus = ToDo, alertTriggered = false, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = true, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = testAlertTriggerDelay, expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = true),
+    TestDefinition(workItemStatus = Failed, alertTriggered = true, workItemAge = Duration("1h"), expectedResult = false),
+    TestDefinition(workItemStatus = Failed, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false)
+  )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+
+    reset(appConfig)
+    when(appConfig.sendEmailPagerDutyAlertTriggerDelay).thenReturn(testAlertTriggerDelay)
+  }
+
+  "PagerDutyAlertManager on isPagerDutyAlertRequiredFor" when {
+
+    testDefinitions.foreach { testDefinition =>
+      s"WorkItem status is '${testDefinition.workItemStatus}', alertTriggered field equals ${testDefinition.alertTriggered}" +
+        s" and receivedAt field is ${testDefinition.workItemAge} in the past" should {
+        s"return ${testDefinition.expectedResult}" in {
+
+          val receivedAtValue = now.minus(testDefinition.workItemAge.toMillis)
+
+          val testWorkItem = WorkItem[SendEmailDetails](
+            id = BSONObjectID.generate,
+            receivedAt = receivedAtValue,
+            updatedAt = now,
+            availableAt = now,
+            status = testDefinition.workItemStatus,
+            failureCount = 0,
+            item = SendEmailDetails(notificationId = BSONObjectID.generate, mrn = ExportsTestData.mrn, alertTriggered = testDefinition.alertTriggered)
+          )
+
+          pagerDutyAlertManager.isPagerDutyAlertRequiredFor(testWorkItem) mustBe testDefinition.expectedResult
+        }
+      }
+    }
+  }
+
+}
+
+object PagerDutyAlertValidatorSpec {
+  private case class TestDefinition(workItemStatus: ProcessingStatus, alertTriggered: Boolean, workItemAge: Duration, expectedResult: Boolean)
+}

--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/SendEmailsJobSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/SendEmailsJobSpec.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.exports.scheduler.jobs
+package uk.gov.hmrc.exports.scheduler.jobs.emails
 
 import java.time._
 
 import org.joda.time.DateTime
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
+import reactivemongo.api.ReadPreference
 import reactivemongo.bson.BSONObjectID
 import testdata.WorkItemTestData._
 import uk.gov.hmrc.exports.base.UnitSpec
@@ -39,8 +40,9 @@ class SendEmailsJobSpec extends UnitSpec {
   private val appConfig = mock[AppConfig]
   private val sendEmailWorkItemRepository = mock[SendEmailWorkItemRepository]
   private val emailSender = mock[EmailSender]
+  private val pagerDutyAlertManager = mock[PagerDutyAlertManager]
 
-  private val sendEmailsJob = new SendEmailsJob(appConfig, sendEmailWorkItemRepository, emailSender)
+  private val sendEmailsJob = new SendEmailsJob(appConfig, sendEmailWorkItemRepository, emailSender, pagerDutyAlertManager)
 
   private val zone = ZoneOffset.UTC
   private def instant(datetime: String): Instant = LocalDateTime.parse(datetime).atZone(zone).toInstant
@@ -48,9 +50,10 @@ class SendEmailsJobSpec extends UnitSpec {
   override def beforeEach(): Unit = {
     super.beforeEach()
 
-    reset(appConfig, sendEmailWorkItemRepository, emailSender)
+    reset(appConfig, sendEmailWorkItemRepository, emailSender, pagerDutyAlertManager)
     when(appConfig.sendEmailsJobInterval).thenReturn(5.minutes)
     when(appConfig.consideredFailedBeforeWorkItem).thenReturn(4.minutes)
+    when(pagerDutyAlertManager.isPagerDutyAlertRequiredFor(any[WorkItem[SendEmailDetails]])).thenReturn(false)
   }
 
   "SendEmailsJob" should {
@@ -102,11 +105,20 @@ class SendEmailsJobSpec extends UnitSpec {
 
         verifyZeroInteractions(emailSender)
       }
+
+      "not call PagerDutyAlertManager" in {
+        when(sendEmailWorkItemRepository.pullOutstanding(any[DateTime], any[DateTime])(any[ExecutionContext])).thenReturn(Future.successful(None))
+
+        sendEmailsJob.execute().futureValue
+
+        verifyZeroInteractions(pagerDutyAlertManager)
+      }
     }
 
     "SendEmailWorkItemRepository returns WorkItem" when {
 
-      val testWorkItem: WorkItem[SendEmailDetails] = buildTestWorkItem(status = ToDo)
+      val testWorkItem: WorkItem[SendEmailDetails] = buildTestWorkItem(status = InProgress)
+      val testWorkItemUpdated: WorkItem[SendEmailDetails] = testWorkItem.copy(status = Failed)
 
       def whenThereIsWorkItemAvailable(): Unit =
         when(sendEmailWorkItemRepository.pullOutstanding(any[DateTime], any[DateTime])(any))
@@ -114,11 +126,15 @@ class SendEmailsJobSpec extends UnitSpec {
 
       "EmailSender returns EmailAccepted" should {
 
-        "call SendEmailWorkItemRepository to complete the WorkItem" in {
+        def prepareTestScenario(): Unit = {
           whenThereIsWorkItemAvailable()
           when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext])).thenReturn(Future.successful(EmailAccepted))
           when(sendEmailWorkItemRepository.complete(any[BSONObjectID], any[ProcessingStatus with ResultStatus])(any))
             .thenReturn(Future.successful(true))
+        }
+
+        "call SendEmailWorkItemRepository to complete the WorkItem" in {
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 
@@ -126,37 +142,81 @@ class SendEmailsJobSpec extends UnitSpec {
         }
 
         "call SendEmailWorkItemRepository again for the next WorkItem" in {
-          whenThereIsWorkItemAvailable()
-          when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext])).thenReturn(Future.successful(EmailAccepted))
-          when(sendEmailWorkItemRepository.complete(any[BSONObjectID], any[ProcessingStatus with ResultStatus])(any))
-            .thenReturn(Future.successful(true))
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 
           verify(sendEmailWorkItemRepository, times(2)).pullOutstanding(any[DateTime], any[DateTime])(any)
         }
+
+        "not call PagerDutyAlertManager" in {
+          prepareTestScenario()
+
+          sendEmailsJob.execute().futureValue
+
+          verifyZeroInteractions(pagerDutyAlertManager)
+        }
       }
 
       "EmailSender returns BadEmailRequest" should {
 
-        "call SendEmailWorkItemRepository to mark the WorkItem as Failed" in {
+        def prepareTestScenario(): Unit = {
           whenThereIsWorkItemAvailable()
           when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext]))
             .thenReturn(Future.successful(BadEmailRequest("Test BadEmailRequest message")))
           when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
             .thenReturn(Future.successful(true))
+          when(sendEmailWorkItemRepository.findById(any[BSONObjectID], any[ReadPreference])(any[ExecutionContext]))
+            .thenReturn(Future.successful(Some(testWorkItemUpdated)))
+        }
+
+        "call SendEmailWorkItemRepository to mark the WorkItem as Failed" in {
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 
           verify(sendEmailWorkItemRepository).markAs(eqTo(testWorkItem.id), eqTo(Failed), any)(any)
         }
 
+        "call SendEmailWorkItemRepository to fetch the most up-to-date version of WorkItem with status other than InProgress" in {
+          prepareTestScenario()
+
+          sendEmailsJob.execute().futureValue
+
+          verify(sendEmailWorkItemRepository).findById(eqTo(testWorkItem.id), any[ReadPreference])(any[ExecutionContext])
+        }
+
+        "call PagerDutyAlertManager" in {
+          prepareTestScenario()
+
+          sendEmailsJob.execute().futureValue
+
+          verify(pagerDutyAlertManager).isPagerDutyAlertRequiredFor(eqTo(testWorkItemUpdated))
+        }
+
+        "call SendEmailWorkItemRepository to update SendEmailDetails" when {
+          "PagerDutyAlertManager returns true" in {
+            prepareTestScenario()
+            when(pagerDutyAlertManager.isPagerDutyAlertRequiredFor(any[WorkItem[SendEmailDetails]])).thenReturn(true)
+
+            sendEmailsJob.execute().futureValue
+
+            verify(sendEmailWorkItemRepository).markAlertTriggered(eqTo(testWorkItem.id))(any[ExecutionContext])
+          }
+        }
+
+        "NOT call SendEmailWorkItemRepository to update SendEmailDetails" when {
+          "PagerDutyAlertManager returns false" in {
+            prepareTestScenario()
+
+            sendEmailsJob.execute().futureValue
+
+            verify(sendEmailWorkItemRepository, never).markAlertTriggered(any[BSONObjectID])(any[ExecutionContext])
+          }
+        }
+
         "call SendEmailWorkItemRepository again for the next WorkItem" in {
-          whenThereIsWorkItemAvailable()
-          when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext]))
-            .thenReturn(Future.successful(BadEmailRequest("Test BadEmailRequest message")))
-          when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
-            .thenReturn(Future.successful(true))
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 
@@ -166,22 +226,62 @@ class SendEmailsJobSpec extends UnitSpec {
 
       "EmailSender returns MissingData" should {
 
-        "call SendEmailWorkItemRepository to mark the WorkItem as Failed" in {
+        def prepareTestScenario(): Unit = {
           whenThereIsWorkItemAvailable()
           when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext])).thenReturn(Future.successful(MissingData))
           when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
             .thenReturn(Future.successful(true))
+          when(sendEmailWorkItemRepository.findById(any[BSONObjectID], any[ReadPreference])(any[ExecutionContext]))
+            .thenReturn(Future.successful(Some(testWorkItemUpdated)))
+        }
+
+        "call SendEmailWorkItemRepository to mark the WorkItem as Failed" in {
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 
           verify(sendEmailWorkItemRepository).markAs(eqTo(testWorkItem.id), eqTo(Failed), any)(any)
         }
 
+        "call SendEmailWorkItemRepository to fetch the most up-to-date version of WorkItem with status other than InProgress" in {
+          prepareTestScenario()
+
+          sendEmailsJob.execute().futureValue
+
+          verify(sendEmailWorkItemRepository).findById(eqTo(testWorkItem.id), any[ReadPreference])(any[ExecutionContext])
+        }
+
+        "call PagerDutyAlertManager" in {
+          prepareTestScenario()
+
+          sendEmailsJob.execute().futureValue
+
+          verify(pagerDutyAlertManager).isPagerDutyAlertRequiredFor(eqTo(testWorkItemUpdated))
+        }
+
+        "call SendEmailWorkItemRepository to update SendEmailDetails" when {
+          "PagerDutyAlertManager returns true" in {
+            prepareTestScenario()
+            when(pagerDutyAlertManager.isPagerDutyAlertRequiredFor(any[WorkItem[SendEmailDetails]])).thenReturn(true)
+
+            sendEmailsJob.execute().futureValue
+
+            verify(sendEmailWorkItemRepository).markAlertTriggered(eqTo(testWorkItem.id))(any[ExecutionContext])
+          }
+        }
+
+        "NOT call SendEmailWorkItemRepository to update SendEmailDetails" when {
+          "PagerDutyAlertManager returns false" in {
+            prepareTestScenario()
+
+            sendEmailsJob.execute().futureValue
+
+            verify(sendEmailWorkItemRepository, never).markAlertTriggered(any[BSONObjectID])(any[ExecutionContext])
+          }
+        }
+
         "call SendEmailWorkItemRepository again for the next WorkItem" in {
-          whenThereIsWorkItemAvailable()
-          when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext])).thenReturn(Future.successful(MissingData))
-          when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
-            .thenReturn(Future.successful(true))
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 
@@ -191,24 +291,63 @@ class SendEmailsJobSpec extends UnitSpec {
 
       "EmailSender returns InternalEmailServiceError" should {
 
-        "call SendEmailWorkItemRepository to mark the WorkItem as Failed" in {
+        def prepareTestScenario(): Unit = {
           whenThereIsWorkItemAvailable()
           when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext]))
             .thenReturn(Future.successful(InternalEmailServiceError("Test InternalEmailServiceError message")))
           when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
             .thenReturn(Future.successful(true))
+          when(sendEmailWorkItemRepository.findById(any[BSONObjectID], any[ReadPreference])(any[ExecutionContext]))
+            .thenReturn(Future.successful(Some(testWorkItemUpdated)))
+        }
+
+        "call SendEmailWorkItemRepository to mark the WorkItem as Failed" in {
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 
           verify(sendEmailWorkItemRepository).markAs(eqTo(testWorkItem.id), eqTo(Failed), any)(any)
         }
 
+        "call SendEmailWorkItemRepository to fetch the most up-to-date version of WorkItem with status other than InProgress" in {
+          prepareTestScenario()
+
+          sendEmailsJob.execute().futureValue
+
+          verify(sendEmailWorkItemRepository).findById(eqTo(testWorkItem.id), any[ReadPreference])(any[ExecutionContext])
+        }
+
+        "call PagerDutyAlertManager" in {
+          prepareTestScenario()
+
+          sendEmailsJob.execute().futureValue
+
+          verify(pagerDutyAlertManager).isPagerDutyAlertRequiredFor(eqTo(testWorkItemUpdated))
+        }
+
+        "call SendEmailWorkItemRepository to update SendEmailDetails" when {
+          "PagerDutyAlertManager returns true" in {
+            prepareTestScenario()
+            when(pagerDutyAlertManager.isPagerDutyAlertRequiredFor(any[WorkItem[SendEmailDetails]])).thenReturn(true)
+
+            sendEmailsJob.execute().futureValue
+
+            verify(sendEmailWorkItemRepository).markAlertTriggered(eqTo(testWorkItem.id))(any[ExecutionContext])
+          }
+        }
+
+        "NOT call SendEmailWorkItemRepository to update SendEmailDetails" when {
+          "PagerDutyAlertManager returns false" in {
+            prepareTestScenario()
+
+            sendEmailsJob.execute().futureValue
+
+            verify(sendEmailWorkItemRepository, never).markAlertTriggered(any[BSONObjectID])(any[ExecutionContext])
+          }
+        }
+
         "NOT call SendEmailWorkItemRepository again for the next WorkItem" in {
-          whenThereIsWorkItemAvailable()
-          when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext]))
-            .thenReturn(Future.successful(InternalEmailServiceError("Test InternalEmailServiceError message")))
-          when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
-            .thenReturn(Future.successful(true))
+          prepareTestScenario()
 
           sendEmailsJob.execute().futureValue
 


### PR DESCRIPTION
Pager Duty alert triggering is split into 2 classes:
Manager and Validator.
Validator class is responsible only for determination
if PD alert should be triggered or not. 
Manager class collects all data required for Validator
and also it is responsible for triggereing the alert and
updating WorkItem document in Mongo with this 
information.

The split is also there to make it easier to test.