### PR TITLE
BAU Fix PagerDutyAlertValidatorSpec instability

### DIFF
--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidatorSpec.scala
@@ -36,14 +36,19 @@ class PagerDutyAlertValidatorSpec extends UnitSpec {
 
   private val testDefinitions = Seq(
     TestDefinition(workItemStatus = ToDo, alertTriggered = false, workItemAge = Duration("1h"), expectedResult = false),
-    TestDefinition(workItemStatus = ToDo, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1s")), expectedResult = false),
     TestDefinition(workItemStatus = ToDo, alertTriggered = true, workItemAge = Duration("1h"), expectedResult = false),
-    TestDefinition(workItemStatus = ToDo, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false),
+    TestDefinition(workItemStatus = ToDo, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1s")), expectedResult = false),
     TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = Duration("1h"), expectedResult = false),
-    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = testAlertTriggerDelay, expectedResult = false),
-    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = true),
+    TestDefinition(
+      workItemStatus = Failed,
+      alertTriggered = false,
+      workItemAge = testAlertTriggerDelay.minus(Duration("1s")),
+      expectedResult = false
+    ),
+    TestDefinition(workItemStatus = Failed, alertTriggered = false, workItemAge = testAlertTriggerDelay.plus(Duration("1s")), expectedResult = true),
     TestDefinition(workItemStatus = Failed, alertTriggered = true, workItemAge = Duration("1h"), expectedResult = false),
-    TestDefinition(workItemStatus = Failed, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1m")), expectedResult = false)
+    TestDefinition(workItemStatus = Failed, alertTriggered = true, workItemAge = testAlertTriggerDelay.plus(Duration("1s")), expectedResult = false)
   )
 
   override def beforeEach(): Unit = {


### PR DESCRIPTION
For one the test cases Duration parameter was equal to
the threshold value. This was causing the test to fail
randomly.
As a solution, 1 second has been subtracted from this
Duration value. This small time difference is irrelevant
to the whole logic, but ensures the test case pass more
reliably.