### PR TITLE
BAU Improve Declaration Submission performance

### DIFF
--- a/app/uk/gov/hmrc/exports/services/WcoMapperService.scala
+++ b/app/uk/gov/hmrc/exports/services/WcoMapperService.scala
@@ -16,12 +16,14 @@
 
 package uk.gov.hmrc.exports.services
 
-import javax.inject.Inject
-import javax.xml.bind.JAXBElement
 import uk.gov.hmrc.exports.models.declaration.ExportsDeclaration
 import uk.gov.hmrc.exports.services.mapping.SubmissionMetaDataBuilder
 import wco.datamodel.wco.dec_dms._2.Declaration
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
+
+import java.io.StringWriter
+import javax.inject.Inject
+import javax.xml.bind.{JAXBContext, JAXBElement, Marshaller}
 
 class WcoMapperService @Inject()(submissionMetadataBuilder: SubmissionMetaDataBuilder) {
 
@@ -49,12 +51,11 @@ class WcoMapperService @Inject()(submissionMetadataBuilder: SubmissionMetaDataBu
         .getValue
     ).orElse(None)
 
-  def toXml(metaData: MetaData) = {
-    import java.io.StringWriter
+  private lazy val jaxbContext = JAXBContext.newInstance(classOf[MetaData])
 
-    import javax.xml.bind.{JAXBContext, Marshaller}
+  def toXml(metaData: MetaData): String = {
+    val jaxbMarshaller = jaxbContext.createMarshaller
 
-    val jaxbMarshaller = JAXBContext.newInstance(classOf[MetaData]).createMarshaller
     jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true)
 
     val sw = new StringWriter


### PR DESCRIPTION
It turned out that the most time consuming part of XML generation
was the creation of JAXBContent. Full problem description together
with solutions can be found here:
https://www.ibm.com/support/pages/jaxbcontext-initialization-takes-long-time

As you can read in one of the solutions, JAXBContext is bound to a
set of classes/packages and it can be re-used for repeatedly converting
the same model. This is why the context has been made a lazy field in
the class.

This upgrade improves XML generation step approx. 100 times.
Request handling time for Declaration submission is lowered
by approx. 50%.