### PR TITLE
[CEDS-3477] Bug when user tries to view dec without transport payment

### DIFF
--- a/app/uk/gov/hmrc/exports/migrations/MigrationRoutine.scala
+++ b/app/uk/gov/hmrc/exports/migrations/MigrationRoutine.scala
@@ -17,14 +17,14 @@
 package uk.gov.hmrc.exports.migrations
 
 import scala.concurrent.Future
-
 import com.github.cloudyrock.mongock.{Mongock, MongockBuilder}
 import com.google.inject.Singleton
 import com.mongodb.{MongoClient, MongoClientURI}
+
 import javax.inject.Inject
 import play.api.Logger
 import uk.gov.hmrc.exports.config.{AppConfig, ExportsMigrationConfig}
-import uk.gov.hmrc.exports.migrations.changelogs.cache.RenameToAdditionalDocuments
+import uk.gov.hmrc.exports.migrations.changelogs.cache.{MakeTransportPaymentMethodNotOptional, RenameToAdditionalDocuments}
 import uk.gov.hmrc.exports.migrations.changelogs.notification.{MakeParsedDetailsOptional, SplitTheNotificationsCollection}
 import uk.gov.hmrc.exports.routines.{Routine, RoutinesExecutionContext}
 
@@ -54,6 +54,7 @@ class MigrationRoutine @Inject()(appConfig: AppConfig, exportsMigrationConfig: E
       .register(new MakeParsedDetailsOptional())
       .register(new SplitTheNotificationsCollection())
       .register(new RenameToAdditionalDocuments())
+      .register(new MakeTransportPaymentMethodNotOptional())
     val migrationTool = ExportsMigrationTool(db, migrationsRegistry, lockManagerConfig)
 
     migrationTool.execute()

--- a/app/uk/gov/hmrc/exports/migrations/changelogs/cache/MakeTransportPaymentMethodNotOptional.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/cache/MakeTransportPaymentMethodNotOptional.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs.cache
+
+import com.mongodb.client.{MongoCollection, MongoDatabase}
+import org.bson.Document
+import org.mongodb.scala.model.Filters.{and, exists, not, eq => feq}
+import org.mongodb.scala.model.UpdateOneModel
+import org.mongodb.scala.model.Updates.set
+import play.api.Logger
+import uk.gov.hmrc.exports.migrations.changelogs.{MigrationDefinition, MigrationInformation}
+
+import scala.collection.JavaConverters._
+
+class MakeTransportPaymentMethodNotOptional extends MigrationDefinition {
+
+  private val logger = Logger(this.getClass)
+
+  private val INDEX_ID = "id"
+  private val INDEX_EORI = "eori"
+  private val TRANSPORT = "transport"
+  private val TRANSPORT_PAYMENT = "transportPayment"
+
+  override val migrationInformation: MigrationInformation =
+    MigrationInformation(id = "CEDS-3477 Change /transport/transportPayment/paymentMethod", order = 9, author = "Tim Wilkins", runAlways = true)
+
+  override def migrationFunction(db: MongoDatabase): Unit = {
+    logger.info(s"Applying '${migrationInformation.id}' db migration...")
+
+    val queryBatchSize = 10
+    val updateBatchSize = 100
+
+    asScalaIterator(
+      getDeclarationsCollection(db)
+        .find(and(exists("transport.transportPayment"), not(exists("transport.transportPayment.paymentMethod"))))
+        .batchSize(queryBatchSize)
+        .iterator
+    ).map { document =>
+      val transportDoc = document.get(TRANSPORT, classOf[Document])
+      transportDoc.remove(TRANSPORT_PAYMENT)
+      logger.debug(s"Updated: $transportDoc")
+
+      val documentId = document.get(INDEX_ID).asInstanceOf[String]
+      val eori = document.get(INDEX_EORI).asInstanceOf[String]
+      val filter = and(feq(INDEX_ID, documentId), feq(INDEX_EORI, eori))
+      val update = set(TRANSPORT, transportDoc)
+      logger.debug(s"[filter: $filter] [update: $update]")
+
+      new UpdateOneModel[Document](filter, update)
+    }.grouped(updateBatchSize).zipWithIndex.foreach {
+      case (requests, idx) =>
+        logger.info(s"Updating batch no. $idx...")
+
+        getDeclarationsCollection(db).bulkWrite(seqAsJavaList(requests))
+        logger.info(s"Updated batch no. $idx")
+    }
+
+    logger.info(s"Applying '${migrationInformation.id}' db migration... Done.")
+  }
+
+  private def getDeclarationsCollection(db: MongoDatabase): MongoCollection[Document] = {
+    val collectionName = "declarations"
+    db.getCollection(collectionName)
+  }
+}

--- a/test/it/uk/gov/hmrc/exports/migrations/changelogs/cache/MakeTransportPaymentMethodNotOptionalSpec.scala
+++ b/test/it/uk/gov/hmrc/exports/migrations/changelogs/cache/MakeTransportPaymentMethodNotOptionalSpec.scala
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs.cache
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.mongodb.{MongoClient, MongoClientURI}
+import com.mongodb.client.MongoDatabase
+import org.bson.Document
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+import stubs.TestMongoDB
+import stubs.TestMongoDB.mongoConfiguration
+import uk.gov.hmrc.exports.base.IntegrationTestBaseSpec
+import uk.gov.hmrc.exports.migrations.changelogs.cache.MakeTransportPaymentMethodNotOptionalSpec._
+
+class MakeTransportPaymentMethodNotOptionalSpec extends IntegrationTestBaseSpec with GuiceOneAppPerSuite {
+
+  override def fakeApplication(): Application =
+    new GuiceApplicationBuilder()
+      .disable[com.kenshoo.play.metrics.PlayModule]
+      .configure(mongoConfiguration)
+      .build()
+
+  private val MongoURI = mongoConfiguration.get[String]("mongodb.uri")
+  private val DatabaseName = TestMongoDB.DatabaseName
+  private val CollectionName = "declarations"
+
+  private val mongoDatabase: MongoDatabase = {
+    val uri = new MongoClientURI(MongoURI.replaceAllLiterally("sslEnabled", "ssl"))
+    val client = new MongoClient(uri)
+
+    client.getDatabase(DatabaseName)
+  }
+
+  private val changeLog = new MakeTransportPaymentMethodNotOptional()
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    mongoDatabase.getCollection(CollectionName).drop()
+  }
+
+  override def afterEach(): Unit = {
+    mongoDatabase.getCollection(CollectionName).drop()
+    super.afterEach()
+  }
+
+  "MakeTransportPayemntFieldNotOptional migration definition" should {
+
+    "correctly migrate documents removing 'transportPayment' field where 'paymentMethod' is not defined" in {
+      runTest(testDataBeforeRenaming, testDataAfterRenaming)
+    }
+
+    "not change documents already migrated" in {
+      runTest(testDataAfterRenaming, testDataAfterRenaming)
+    }
+
+    "not change documents that have a 'paymentMethod' value" in {
+      runTest(testDataOutOfScope, testDataOutOfScope)
+    }
+  }
+
+  private def runTest(inputDataJson: String, expectedDataJson: String): Unit = {
+    val collection = mongoDatabase.getCollection(CollectionName)
+    collection.insertOne(Document.parse(inputDataJson))
+
+    changeLog.migrationFunction(mongoDatabase)
+
+    val result: Document = collection.find().first()
+    val expectedResult: String = expectedDataJson
+
+    compareJson(result.toJson, expectedResult)
+  }
+
+  private def compareJson(actual: String, expected: String): Unit = {
+    val mapper = new ObjectMapper
+
+    val jsonActual = mapper.readTree(actual)
+    val jsonExpected = mapper.readTree(expected)
+
+    jsonActual mustBe jsonExpected
+  }
+}
+
+object MakeTransportPaymentMethodNotOptionalSpec {
+  val testDataBeforeRenaming: String =
+    """{
+      |  "_id": "60ded91dd3b4338579ff253c",
+      |  "id": "1fb39320-8d0d-4521-ba52-ffc835026e0e",
+      |  "eori": "GB239355053000",
+      |  "type": "SIMPLIFIED",
+      |  "additionalDeclarationType": "F",
+      |  "transport": {
+      |    "transportPayment": {},
+      |    "containers": [],
+      |    "borderModeOfTransportCode": {
+      |      "code": "1"
+      |    },
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "BLUE MASTER II",
+      |    "meansOfTransportCrossingTheBorderNationality": "Marshall Islands (the)",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "BLUE MASTER II"
+      |  }
+      |}""".stripMargin
+
+  val testDataAfterRenaming: String =
+    """{
+      |  "_id": "60ded91dd3b4338579ff253c",
+      |  "id": "1fb39320-8d0d-4521-ba52-ffc835026e0e",
+      |  "eori": "GB239355053000",
+      |  "type": "SIMPLIFIED",
+      |  "additionalDeclarationType": "F",
+      |  "transport": {
+      |    "containers": [],
+      |    "borderModeOfTransportCode": {
+      |      "code": "1"
+      |    },
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "BLUE MASTER II",
+      |    "meansOfTransportCrossingTheBorderNationality": "Marshall Islands (the)",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "BLUE MASTER II"
+      |  }
+      |}""".stripMargin
+
+  val testDataOutOfScope: String =
+    """{
+      |  "_id": "60ddecd93b6074a90796af8a",
+      |  "id": "68880c57-6986-4e21-9576-cdc477d60a43",
+      |  "eori": "GB239355053000",
+      |  "type": "SIMPLIFIED",
+      |  "additionalDeclarationType": "F",
+      |  "transport": {
+      |    "transportPayment": {
+      |      "paymentMethod" : "A"
+      |    },
+      |    "containers": [],
+      |    "borderModeOfTransportCode": {
+      |      "code": "1"
+      |    },
+      |    "meansOfTransportOnDepartureType": "11",
+      |    "meansOfTransportOnDepartureIDNumber": "BLUE MASTER II",
+      |    "meansOfTransportCrossingTheBorderNationality": "Marshall Islands (the)",
+      |    "meansOfTransportCrossingTheBorderType": "11",
+      |    "meansOfTransportCrossingTheBorderIDNumber": "BLUE MASTER II"
+      |  }
+      |}""".stripMargin
+}


### PR DESCRIPTION
Fix bug where a declaration in the cache has a TransportPayment entity with
no 'paymentMethod' field value.

Created a DB migration job to remove any TransportPayment entity with
no 'paymentMethod' field value from declarations in cache.