### PR TITLE
BAU Enhance and simplify declaration submission process

### DIFF
--- a/app/uk/gov/hmrc/exports/repositories/DeclarationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/DeclarationRepository.scala
@@ -97,6 +97,16 @@ class DeclarationRepository @Inject()(mc: ReactiveMongoComponent, appConfig: App
       .map(_.value.map(_.as[ExportsDeclaration]))
   }
 
+  def markCompleted(id: String, eori: Eori): Future[Option[ExportsDeclaration]] =
+    super
+      .findAndUpdate(
+        Json.obj("id" -> id, "eori" -> eori.value),
+        Json.obj("$set" -> Json.obj("status" -> DeclarationStatus.COMPLETE)),
+        fetchNewObject = false,
+        upsert = false
+      )
+      .map(_.value.map(_.as[ExportsDeclaration]))
+
   def delete(declaration: ExportsDeclaration): Future[Unit] =
     super
       .remove("id" -> declaration.id, "eori" -> declaration.eori)

--- a/app/uk/gov/hmrc/exports/services/SubmissionService.scala
+++ b/app/uk/gov/hmrc/exports/services/SubmissionService.scala
@@ -64,13 +64,8 @@ class SubmissionService @Inject()(
 
     val payload = metrics.timeCall(Timers.submissionConvertToXmlTimer)(wcoMapperService.toXml(metaData))
 
+    logProgress(declaration, "Submitting to the Declaration API")
     for {
-      // Update the Declaration Status
-      _ <- metrics.timeCall(Timers.submissionUpdateDeclarationTimer)(
-        declarationRepository.update(declaration.copy(status = DeclarationStatus.COMPLETE))
-      )
-      _ = logProgress(declaration, "Marked as COMPLETE")
-
       // Create the Submission
       submission <- metrics.timeAsyncCall(Timers.submissionFindOrCreateSubmissionTimer)(
         submissionRepository.findOrCreate(Eori(declaration.eori), declaration.id, Submission(declaration, lrn, ducr))

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -144,7 +144,6 @@ class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with
         when(wcoMapperService.declarationLrn(any())).thenReturn(Some("lrn"))
         when(wcoMapperService.declarationDucr(any())).thenReturn(Some("ducr"))
         when(wcoMapperService.toXml(any())).thenReturn("xml")
-        when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
         when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
         when(customsDeclarationsConnector.submitDeclaration(any(), any())(any()))
           .thenReturn(Future.successful("conv-id"))
@@ -161,8 +160,6 @@ class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with
         action.id mustBe "conv-id"
         action.requestType mustBe SubmissionRequest
 
-        theDeclarationUpdated().status mustEqual DeclarationStatus.COMPLETE
-
         verify(submissionRepository, never).updateMrn(any[String], any[String])
         verify(sendEmailForDmsDocAction, never).execute(any[String])
       }
@@ -173,7 +170,6 @@ class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with
         when(wcoMapperService.declarationLrn(any())).thenReturn(Some("lrn"))
         when(wcoMapperService.declarationDucr(any())).thenReturn(Some("ducr"))
         when(wcoMapperService.toXml(any())).thenReturn("xml")
-        when(declarationRepository.update(any())).thenReturn(Future.successful(Some(mock[ExportsDeclaration])))
         when(submissionRepository.findOrCreate(any(), any(), any())).thenReturn(Future.successful(mock[Submission]))
         when(customsDeclarationsConnector.submitDeclaration(any(), any())(any()))
           .thenReturn(Future.successful("conv-id"))
@@ -191,8 +187,6 @@ class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with
         val action = theActionAdded()
         action.id mustBe "conv-id"
         action.requestType mustBe SubmissionRequest
-
-        theDeclarationUpdated().status mustEqual DeclarationStatus.COMPLETE
 
         verify(submissionRepository).updateMrn(meq("conv-id"), meq("mrn"))
         verify(sendEmailForDmsDocAction).execute(meq("conv-id"))
@@ -223,8 +217,7 @@ class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with
 
         verify(submissionRepository, never).addAction(any[Submission], any[Action])
 
-        theDeclarationUpdated(0).status mustEqual DeclarationStatus.COMPLETE
-        theDeclarationUpdated(1).status mustEqual DeclarationStatus.DRAFT
+        theDeclarationUpdated().status mustEqual DeclarationStatus.DRAFT
       }
     }
 


### PR DESCRIPTION
After this change, Declaration document in MongoDB has
its status changed to 'complete' at the time of fetching,
instead of updating it later in the process.

This change prevents a situation where calling the
submission process twice in a short period of time
could result in double submission due to race
condition (previously, declaration status was updated
as a separate operation in Mongo, after checking the
status of fetched declaration).