### PR TITLE
[CEDS-3527] Skip 67A which has no sequence number

### DIFF
--- a/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
@@ -62,6 +62,8 @@ class NotificationParser {
       }
     } else Seq.empty
 
+  private val pointerSection67A = Some(PointerSection("67A", PointerSectionType.FIELD))
+
   private def buildErrorPointer(singleErrorXml: Node): Option[Pointer] = {
     val pointersXml = singleErrorXml \ "Pointer"
 
@@ -75,9 +77,10 @@ class NotificationParser {
 
       /**
         * Sequence Numeric define what item is related with error, this is for future implementation - optional
+        * Additional filter to ignore any sequence numbers for section 67A (CEDS-3527)
         */
       val sequenceNumeric: Option[PointerSection] =
-        if ((singlePointerXml \ "SequenceNumeric").nonEmpty)
+        if ((singlePointerXml \ "SequenceNumeric").nonEmpty && documentSectionCode != pointerSection67A)
           Some(PointerSection((singlePointerXml \ "SequenceNumeric").text, PointerSectionType.SEQUENCE))
         else None
 
@@ -97,5 +100,4 @@ class NotificationParser {
     if (exportsPointer.isEmpty) logger.warn(s"Missing pointer mapping for [${wcoPointer}]")
     exportsPointer
   }
-
 }

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
@@ -61,6 +61,16 @@ class NotificationParserSpec extends UnitSpec {
           result mustBe testNotification.asDomainModel
         }
       }
+
+      "contains error element 67A with a sequence number" should {
+        "ignore the sequence number for that section" in {
+          val testNotification = exampleRejectNotification(mrn, with67ASequenceNo = true)
+
+          val result = notificationParser.parse(testNotification.asXml)
+
+          result mustBe testNotification.asDomainModel
+        }
+      }
     }
 
     "provided with notification containing multiple Response elements" should {

--- a/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
+++ b/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
@@ -69,7 +69,8 @@ object ExampleXmlAndNotificationDetailsPair {
   //noinspection ScalaStyle
   def exampleRejectNotification(
     mrn: String,
-    dateTime: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(formatter304)
+    dateTime: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(formatter304),
+    with67ASequenceNo: Boolean = false
   ): ExampleXmlAndNotificationDetailsPair = ExampleXmlAndNotificationDetailsPair(
     asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
       <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
@@ -90,6 +91,7 @@ object ExampleXmlAndNotificationDetailsPair {
             <DocumentSectionCode>42A</DocumentSectionCode>
           </Pointer>
           <Pointer>
+            {if (with67ASequenceNo) <SequenceNumeric>1</SequenceNumeric>}
             <DocumentSectionCode>67A</DocumentSectionCode>
           </Pointer>
           <Pointer>


### PR DESCRIPTION
If we encounter a WCO Error Pointer that has field '67A' with its own sequence number, ignore the sequence number.