### PR TITLE
Ceds 3784 optimise use of mongo store when submitting declarations

### DIFF
--- a/app/uk/gov/hmrc/exports/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/exports/config/AppConfig.scala
@@ -66,6 +66,10 @@ class AppConfig @Inject()(val configuration: Configuration, val environment: Env
   )
 
   lazy val sendEmailsJobInterval: FiniteDuration = servicesConfig.getDuration("scheduler.send-emails.interval").asInstanceOf[FiniteDuration]
+
+  lazy val notificationReattemptInterval: FiniteDuration =
+    servicesConfig.getDuration("scheduler.notification-reattempt.interval").asInstanceOf[FiniteDuration]
+
   lazy val consideredFailedBeforeWorkItem: FiniteDuration =
     servicesConfig.getDuration("workItem.sendEmail.consideredFailedBefore").asInstanceOf[FiniteDuration]
   lazy val sendEmailPagerDutyAlertTriggerDelay: FiniteDuration =

--- a/app/uk/gov/hmrc/exports/migrations/MigrationRoutine.scala
+++ b/app/uk/gov/hmrc/exports/migrations/MigrationRoutine.scala
@@ -22,6 +22,7 @@ import play.api.Logger
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.exports.migrations.changelogs.cache.{MakeTransportPaymentMethodNotOptional, RenameToAdditionalDocuments}
 import uk.gov.hmrc.exports.migrations.changelogs.notification.{MakeParsedDetailsOptional, SplitTheNotificationsCollection}
+import uk.gov.hmrc.exports.migrations.changelogs.submission.RemoveRedundantIndexes
 import uk.gov.hmrc.exports.routines.{Routine, RoutinesExecutionContext}
 
 import javax.inject.Inject
@@ -48,6 +49,7 @@ class MigrationRoutine @Inject()(appConfig: AppConfig)(implicit mec: RoutinesExe
       .register(new SplitTheNotificationsCollection())
       .register(new RenameToAdditionalDocuments())
       .register(new MakeTransportPaymentMethodNotOptional())
+      .register(new RemoveRedundantIndexes())
     val migrationTool = ExportsMigrationTool(db, migrationsRegistry, lockManagerConfig)
 
     migrationTool.execute()

--- a/app/uk/gov/hmrc/exports/migrations/changelogs/submission/RemoveRedundantIndexes.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/submission/RemoveRedundantIndexes.scala
@@ -77,14 +77,16 @@ class RemoveRedundantIndexes extends MigrationDefinition {
     logger.info(s"Applying '${migrationInformation.id}' db migration... Done.")
   }
 
-  private def dropIndexesIfTheyExist(collection: MongoCollection[Document], indexNamesToDrop: Seq[String]) = {
-    collection.listIndexes()
-      .iterator().asScala.toSeq
-      .filter( doc => indexNamesToDrop.contains(doc.getString("name")))
-      .foreach{ doc =>
+  private def dropIndexesIfTheyExist(collection: MongoCollection[Document], indexNamesToDrop: Seq[String]) =
+    collection
+      .listIndexes()
+      .iterator()
+      .asScala
+      .toSeq
+      .filter(doc => indexNamesToDrop.contains(doc.getString("name")))
+      .foreach { doc =>
         val idxName = doc.getString("name")
         collection.dropIndex(idxName)
         logger.info(s"Dropped Index '$idxName' of collection ${collection.getNamespace} as part of db migration!")
       }
-  }
 }

--- a/app/uk/gov/hmrc/exports/migrations/changelogs/submission/RemoveRedundantIndexes.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/submission/RemoveRedundantIndexes.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs.submission
+
+import com.mongodb.client._
+import org.bson.Document
+import play.api.Logger
+import uk.gov.hmrc.exports.migrations.changelogs.{MigrationDefinition, MigrationInformation}
+
+import scala.collection.JavaConverters._
+
+class RemoveRedundantIndexes extends MigrationDefinition {
+
+  private val logger = Logger(this.getClass)
+
+  override val migrationInformation: MigrationInformation =
+    MigrationInformation(id = "CEDS-3784 Drop unused indexes or those we are modifying", order = 10, author = "Tim Wilkins", runAlways = true)
+
+  override def migrationFunction(db: MongoDatabase): Unit = {
+    logger.info(s"Applying '${migrationInformation.id}' db migration...  ")
+
+    dropIndexesIfTheyExist(db.getCollection("submissions"), List("eoriIdx", "updateTimeIdx"))
+    dropIndexesIfTheyExist(db.getCollection("notifications"), List("actionIdIdx", "detailsDateTimeIssuedIdx"))
+
+    logger.info(s"Applying '${migrationInformation.id}' db migration... Done.")
+  }
+
+  private def dropIndexesIfTheyExist(collection: MongoCollection[Document], indexNamesToDrop: Seq[String]) = {
+    collection.listIndexes()
+      .iterator().asScala.toSeq
+      .filter( doc => indexNamesToDrop.contains(doc.getString("name")))
+      .foreach{ doc =>
+        val idxName = doc.getString("name")
+        collection.dropIndex(idxName)
+        logger.info(s"Dropped Index '$idxName' of collection ${collection.getNamespace} as part of db migration!")
+      }
+  }
+}

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/Submission.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/Submission.scala
@@ -32,8 +32,12 @@ case class Submission(
 
 object Submission {
 
+  @deprecated
   def apply(declaration: ExportsDeclaration, lrn: String, ducr: String): Submission =
     new Submission(declaration.id, declaration.eori, lrn, None, ducr, Seq.empty)
+
+  def apply(declaration: ExportsDeclaration, lrn: String, ducr: String, action: Action): Submission =
+    new Submission(declaration.id, declaration.eori, lrn, None, ducr, Seq(action))
 
   implicit val formats = Json.format[Submission]
 }

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/Submission.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/Submission.scala
@@ -32,10 +32,6 @@ case class Submission(
 
 object Submission {
 
-  @deprecated
-  def apply(declaration: ExportsDeclaration, lrn: String, ducr: String): Submission =
-    new Submission(declaration.id, declaration.eori, lrn, None, ducr, Seq.empty)
-
   def apply(declaration: ExportsDeclaration, lrn: String, ducr: String, action: Action): Submission =
     new Submission(declaration.id, declaration.eori, lrn, None, ducr, Seq(action))
 

--- a/app/uk/gov/hmrc/exports/models/emails/SendEmailDetails.scala
+++ b/app/uk/gov/hmrc/exports/models/emails/SendEmailDetails.scala
@@ -20,7 +20,7 @@ import play.api.libs.json._
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 
-case class SendEmailDetails(notificationId: BSONObjectID, mrn: String, alertTriggered: Boolean = false)
+case class SendEmailDetails(notificationId: BSONObjectID, mrn: String, actionId: String, alertTriggered: Boolean = false)
 
 object SendEmailDetails {
   implicit val idFormat = ReactiveMongoFormats.objectIdFormats

--- a/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
@@ -64,7 +64,4 @@ class ParsedNotificationRepository @Inject()(mc: ReactiveMongoComponent)(implici
       case Seq() => Future.successful(Seq.empty)
       case _     => find("$or" -> actionIds.map(id => Json.obj("actionId" -> JsString(id))))
     }
-
-  @deprecated
-  def findNotificationsByMrn(mrn: String): Future[Seq[ParsedNotification]] = find("details.mrn" -> JsString(mrn))
 }

--- a/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
@@ -42,7 +42,6 @@ class ParsedNotificationRepository @Inject()(mc: ReactiveMongoComponent)(implici
     mongo().collection[JSONCollection](collectionName, failoverStrategy = RepositorySettings.failoverStrategy)
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq("details.mrn" -> IndexType.Ascending), name = Some("detailsMrnIdx")),
     Index(Seq("actionId" -> IndexType.Ascending, "details.dateTimeIssued" -> IndexType.Ascending), name = Some("detailsDateTimeIssuedOrderedActionId"))
   )
 
@@ -63,5 +62,6 @@ class ParsedNotificationRepository @Inject()(mc: ReactiveMongoComponent)(implici
       case _     => find("$or" -> actionIds.map(id => Json.obj("actionId" -> JsString(id))))
     }
 
+  @deprecated
   def findNotificationsByMrn(mrn: String): Future[Seq[ParsedNotification]] = find("details.mrn" -> JsString(mrn))
 }

--- a/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
@@ -42,9 +42,8 @@ class ParsedNotificationRepository @Inject()(mc: ReactiveMongoComponent)(implici
     mongo().collection[JSONCollection](collectionName, failoverStrategy = RepositorySettings.failoverStrategy)
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq("details.dateTimeIssued" -> IndexType.Ascending), name = Some("detailsDateTimeIssuedIdx")),
     Index(Seq("details.mrn" -> IndexType.Ascending), name = Some("detailsMrnIdx")),
-    Index(Seq("actionId" -> IndexType.Ascending), name = Some("actionIdIdx"))
+    Index(Seq("actionId" -> IndexType.Ascending, "details.dateTimeIssued" -> IndexType.Ascending), name = Some("detailsDateTimeIssuedOrderedActionId"))
   )
 
   def findLatestNotification(actionIds: Seq[String]): Future[Option[ParsedNotification]] =

--- a/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/ParsedNotificationRepository.scala
@@ -42,7 +42,10 @@ class ParsedNotificationRepository @Inject()(mc: ReactiveMongoComponent)(implici
     mongo().collection[JSONCollection](collectionName, failoverStrategy = RepositorySettings.failoverStrategy)
 
   override def indexes: Seq[Index] = Seq(
-    Index(Seq("actionId" -> IndexType.Ascending, "details.dateTimeIssued" -> IndexType.Ascending), name = Some("detailsDateTimeIssuedOrderedActionId"))
+    Index(
+      Seq("actionId" -> IndexType.Ascending, "details.dateTimeIssued" -> IndexType.Ascending),
+      name = Some("detailsDateTimeIssuedOrderedActionId")
+    )
   )
 
   def findLatestNotification(actionIds: Seq[String]): Future[Option[ParsedNotification]] =

--- a/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
@@ -24,7 +24,6 @@ import reactivemongo.api.indexes.{Index, IndexType}
 import reactivemongo.bson.{BSONBoolean, BSONDocument, BSONObjectID}
 import reactivemongo.play.json.ImplicitBSONHandlers
 import reactivemongo.play.json.collection.JSONCollection
-import uk.gov.hmrc.exports.models.Eori
 import uk.gov.hmrc.exports.models.declaration.submissions.{Action, Submission, SubmissionQueryParameters}
 import uk.gov.hmrc.mongo.ReactiveRepository
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.objectIdFormats
@@ -49,16 +48,7 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
     Index(Seq("eori" -> IndexType.Ascending, "action.requestTimestamp" -> IndexType.Descending), name = Some("actionOrderedEori"))
   )
 
-  def findOrCreate(eori: Eori, id: String, onMissing: Submission): Future[Submission] =
-    findBy(eori.value, SubmissionQueryParameters(uuid = Some(id))).flatMap {
-      case Nil         => save(onMissing)
-      case submissions => Future.successful(submissions.head)
-    }
-
-  @deprecated
-  def findSubmissionByMrn(mrn: String): Future[Option[Submission]] = find("mrn" -> mrn).map(_.headOption)
-
-  //TODO: see why we are looking up by MRN field that is not indexed!
+  //looking up by MRN field that is not indexed (eori is though)! This is for the cancelation request processing!
   def findSubmissionByMrnAndEori(mrn: String, eori: String): Future[Option[Submission]] = find("eori" -> eori, "mrn" -> mrn).map(_.headOption)
 
   def findByConversationId(conversationId: String): Future[Option[Submission]] = find("actions.id" -> conversationId).map(_.headOption)
@@ -77,8 +67,8 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
     submission
   }
 
-  def updateMrn(conversationId: String, newMrn: String): Future[Option[Submission]] = {
-    val query = Json.obj("actions.id" -> conversationId)
+  def setMrnIfMissing(conversationId: String, newMrn: String): Future[Option[Submission]] = {
+    val query = Json.obj("actions.id" -> conversationId, "mrn" -> Json.obj("$exists" -> false))
     val update = Json.obj("$set" -> Json.obj("mrn" -> newMrn))
     performUpdate(query, update)
   }

--- a/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
@@ -46,9 +46,7 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
       name = Some("actionIdIdx"),
       partialFilter = Some(BSONDocument(Seq("actions.id" -> BSONDocument("$exists" -> BSONBoolean(true)))))
     ),
-    Index(Seq("eori" -> IndexType.Ascending), name = Some("eoriIdx")),
-    Index(Seq("eori" -> IndexType.Ascending, "action.requestTimestamp" -> IndexType.Descending), name = Some("actionOrderedEori")),
-    Index(Seq("updatedDateTime" -> IndexType.Ascending), name = Some("updateTimeIdx"))
+    Index(Seq("eori" -> IndexType.Ascending, "action.requestTimestamp" -> IndexType.Descending), name = Some("actionOrderedEori"))
   )
 
   def findOrCreate(eori: Eori, id: String, onMissing: Submission): Future[Submission] =

--- a/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
@@ -55,9 +55,13 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
       case submissions => Future.successful(submissions.head)
     }
 
+  @deprecated
   def findSubmissionByMrn(mrn: String): Future[Option[Submission]] = find("mrn" -> mrn).map(_.headOption)
 
-  def findSubmissionByMrnAndEori(mrn: String, eori: String): Future[Option[Submission]] = find("mrn" -> mrn, "eori" -> eori).map(_.headOption)
+  //TODO: see why we are looking up by MRN field that is not indexed!
+  def findSubmissionByMrnAndEori(mrn: String, eori: String): Future[Option[Submission]] = find("eori" -> eori, "mrn" -> mrn).map(_.headOption)
+
+  def findByConversationId(conversationId: String): Future[Option[Submission]] = find("actions.id" -> conversationId).map(_.headOption)
 
   def findBy(eori: String, queryParameters: SubmissionQueryParameters): Future[Seq[Submission]] = {
     val query = Json.toJson(queryParameters).as[JsObject] + (otherField = ("eori", JsString(eori)))

--- a/app/uk/gov/hmrc/exports/routines/ReattemptNotificationParsingRoutine.scala
+++ b/app/uk/gov/hmrc/exports/routines/ReattemptNotificationParsingRoutine.scala
@@ -27,9 +27,9 @@ class ReattemptNotificationParsingRoutine @Inject()(notificationReceiptActionsRu
 ) extends Routine with Logging {
 
   def execute(): Future[Unit] = {
-    logger.info("Starting ReattemptNotificationParsingRoutine...")
+    logger.debug("Starting ReattemptNotificationParsingRoutine...")
     notificationReceiptActionsRunner.runNow(parseFailed = true).map { _ =>
-      logger.info("Finished ReattemptNotificationParsingRoutine")
+      logger.debug("Finished ReattemptNotificationParsingRoutine")
     }
   }
 }

--- a/app/uk/gov/hmrc/exports/scheduler/jobs/emails/EmailCancellationValidator.scala
+++ b/app/uk/gov/hmrc/exports/scheduler/jobs/emails/EmailCancellationValidator.scala
@@ -29,7 +29,7 @@ private[emails] class EmailCancellationValidator @Inject()(notificationRepositor
   private val statusesCancellingEmailSending = Set(REJECTED, CLEARED, CANCELLED)
 
   def isEmailSendingCancelled(sendEmailDetails: SendEmailDetails)(implicit ec: ExecutionContext): Future[Boolean] =
-    notificationRepository.findNotificationsByMrn(sendEmailDetails.mrn).map { notifications =>
+    notificationRepository.findNotificationsByActionId(sendEmailDetails.actionId).map { notifications =>
       val currentDmsDocNotification = notifications
         .find(_._id == sendEmailDetails.notificationId)
         .getOrElse(throw new IllegalStateException(s"Cannot find DMSDOC Notification with id: [${sendEmailDetails.notificationId}]"))

--- a/app/uk/gov/hmrc/exports/scheduler/jobs/emails/SendEmailsJob.scala
+++ b/app/uk/gov/hmrc/exports/scheduler/jobs/emails/SendEmailsJob.scala
@@ -91,7 +91,7 @@ class SendEmailsJob @Inject()(
   }
 
   private def sendEmail(workItem: WorkItem[SendEmailDetails]): Future[SendEmailResult] =
-    emailSender.sendEmailForDmsDocNotification(workItem.item.mrn).andThen {
+    emailSender.sendEmailForDmsDocNotification(workItem.item).andThen {
       case Success(EmailAccepted) =>
         logger.info(s"Email sent for MRN: ${workItem.item.mrn}")
         sendEmailWorkItemRepository.complete(workItem.id, Succeeded)

--- a/app/uk/gov/hmrc/exports/services/notifications/NotificationProcessingException.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/NotificationProcessingException.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.notifications
+
+final class NotificationProcessingException(message: String) extends RuntimeException(message)

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveAction.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveAction.scala
@@ -53,7 +53,7 @@ class ParseAndSaveAction @Inject()(
       })
       .map(_ => ())
 
-  private def updateRelatedSubmission(notification: ParsedNotification): Future[Option[Submission]] = {
+  private def updateRelatedSubmission(notification: ParsedNotification): Future[Option[Submission]] =
     submissionRepository.findByConversationId(notification.actionId).flatMap { maybeSubmission =>
       if (maybeSubmission.exists(_.mrn.isEmpty)) {
         submissionRepository.updateMrn(notification.actionId, notification.details.mrn).andThen {
@@ -63,5 +63,4 @@ class ParseAndSaveAction @Inject()(
       } else
         Future.successful(maybeSubmission)
     }
-  }
 }

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocAction.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocAction.scala
@@ -33,7 +33,7 @@ class SendEmailForDmsDocAction @Inject()(
     notificationRepository.findNotificationsByActionId(actionId).map { notifications =>
       notifications.map { notification =>
         if (notification.details.status == SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED) {
-          val sendEmailDetails = SendEmailDetails(notificationId = notification._id, mrn = notification.details.mrn)
+          val sendEmailDetails = SendEmailDetails(notificationId = notification._id, actionId = notification.actionId, mrn = notification.details.mrn)
           sendEmailWorkItemRepository.pushNew(sendEmailDetails)
 
         } else

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -207,7 +207,7 @@ scheduler {
     }
 
     send-emails.interval = "5m"
-    notification-receipt-actions.interval = "5s"
+    notification-reattempt.interval = "60s"
 }
 
 play.http.parser.maxMemoryBuffer=10M

--- a/test/it/uk/gov/hmrc/exports/repositories/ParsedNotificationRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/exports/repositories/ParsedNotificationRepositorySpec.scala
@@ -189,38 +189,4 @@ class ParsedNotificationRepositorySpec extends IntegrationTestBaseSpec {
       }
     }
   }
-
-  "Notification Repository on findNotificationsByMrn" when {
-
-    "there is no Notification with given mrn" should {
-      "return empty list" in {
-        repo.findNotificationsByMrn(mrn).futureValue must equal(Seq.empty)
-      }
-    }
-
-    "there is single Notification with given mrn" should {
-      "return this Notification only" in {
-        repo.insert(notification).futureValue
-
-        val foundNotifications = repo.findNotificationsByMrn(mrn).futureValue
-
-        foundNotifications.length must equal(1)
-        foundNotifications.head must equal(notification)
-      }
-    }
-
-    "there are multiple Notifications with given mrn" should {
-      "return all the Notifications" in {
-        repo.insert(notification).futureValue
-        repo.insert(notification_2).futureValue
-
-        val foundNotifications = repo.findNotificationsByMrn(mrn).futureValue
-
-        foundNotifications.length must equal(2)
-        foundNotifications must contain(notification)
-        foundNotifications must contain(notification_2)
-      }
-    }
-  }
-
 }

--- a/test/it/uk/gov/hmrc/exports/repositories/SendEmailWorkItemRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/exports/repositories/SendEmailWorkItemRepositorySpec.scala
@@ -58,8 +58,8 @@ class SendEmailWorkItemRepositorySpec extends IntegrationTestBaseSpec {
       "trying to insert WorkItem with duplicated 'notificationId' field" in {
 
         val id = BSONObjectID.generate
-        val testSendEmailWorkItem_1 = SendEmailDetails(notificationId = id, mrn = ExportsTestData.mrn)
-        val testSendEmailWorkItem_2 = SendEmailDetails(notificationId = id, mrn = ExportsTestData.mrn_2)
+        val testSendEmailWorkItem_1 = SendEmailDetails(notificationId = id, mrn = ExportsTestData.mrn, actionId = "actionId")
+        val testSendEmailWorkItem_2 = SendEmailDetails(notificationId = id, mrn = ExportsTestData.mrn_2, actionId = "actionId")
 
         repo.pushNew(testSendEmailWorkItem_1).futureValue
 

--- a/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
@@ -50,9 +50,8 @@ object UnitTestMockBuilder extends MockitoSugar {
     when(submissionRepositoryMock.addAction(any[String](), any())).thenReturn(Future.successful(None))
     when(submissionRepositoryMock.addAction(any[Submission](), any())).thenReturn(Future.successful(mock[Submission]))
     when(submissionRepositoryMock.findBy(any(), any())).thenReturn(Future.successful(Seq.empty))
-    when(submissionRepositoryMock.findSubmissionByMrn(any())).thenReturn(Future.successful(None))
     when(submissionRepositoryMock.save(any())).thenReturn(Future.successful(mock[Submission]))
-    when(submissionRepositoryMock.updateMrn(any(), any())).thenReturn(Future.successful(None))
+    when(submissionRepositoryMock.setMrnIfMissing(any(), any())).thenReturn(Future.successful(None))
     submissionRepositoryMock
   }
 

--- a/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/config/AppConfigSpec.scala
@@ -41,6 +41,7 @@ class AppConfigSpec extends AnyFunSuite with Matchers with GuiceOneAppPerSuite {
   val draftTimeToLive: FiniteDuration = 30.days
   val purgeDraftDeclarations = JobConfig(LocalTime.of(23, 30), 1.day)
   val sendEmailsJobInterval: FiniteDuration = 5.minutes
+  val notificationReattemptInterval: FiniteDuration = 60.seconds
   val sendEmailPagerDutyAlertTriggerDelay: FiniteDuration = 1.day
   val consideredFailedBeforeWorkItem: FiniteDuration = 4.minutes
   val customsDeclarationsInformationBaseUrl = "http://localhost:9834"
@@ -87,6 +88,10 @@ class AppConfigSpec extends AnyFunSuite with Matchers with GuiceOneAppPerSuite {
 
   test(s"sendEmailsJobInterval must be $sendEmailsJobInterval") {
     appConfig.sendEmailsJobInterval mustBe sendEmailsJobInterval
+  }
+
+  test(s"notificationReattemptInterval must be $notificationReattemptInterval") {
+    appConfig.notificationReattemptInterval mustBe notificationReattemptInterval
   }
 
   test(s"consideredFailedBeforeWorkItem must be $consideredFailedBeforeWorkItem") {

--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/PagerDutyAlertValidatorSpec.scala
@@ -74,7 +74,12 @@ class PagerDutyAlertValidatorSpec extends UnitSpec {
             availableAt = now,
             status = testDefinition.workItemStatus,
             failureCount = 0,
-            item = SendEmailDetails(notificationId = BSONObjectID.generate, mrn = ExportsTestData.mrn, alertTriggered = testDefinition.alertTriggered)
+            item = SendEmailDetails(
+              notificationId = BSONObjectID.generate,
+              mrn = ExportsTestData.mrn,
+              actionId = "actionId",
+              alertTriggered = testDefinition.alertTriggered
+            )
           )
 
           pagerDutyAlertManager.isPagerDutyAlertRequiredFor(testWorkItem) mustBe testDefinition.expectedResult
@@ -82,7 +87,6 @@ class PagerDutyAlertValidatorSpec extends UnitSpec {
       }
     }
   }
-
 }
 
 object PagerDutyAlertValidatorSpec {

--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/SendEmailsJobSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/SendEmailsJobSpec.scala
@@ -194,7 +194,8 @@ class SendEmailsJobSpec extends UnitSpec {
 
           def prepareTestScenario(): Unit = {
             whenThereIsWorkItemAvailable()
-            when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext])).thenReturn(Future.successful(EmailAccepted))
+            when(emailSender.sendEmailForDmsDocNotification(any[SendEmailDetails])(any[ExecutionContext]))
+              .thenReturn(Future.successful(EmailAccepted))
             when(sendEmailWorkItemRepository.complete(any[BSONObjectID], any[ProcessingStatus with ResultStatus])(any))
               .thenReturn(Future.successful(true))
             when(emailCancellationValidator.isEmailSendingCancelled(any[SendEmailDetails])(any)).thenReturn(Future.successful(false))
@@ -229,7 +230,7 @@ class SendEmailsJobSpec extends UnitSpec {
 
           def prepareTestScenario(): Unit = {
             whenThereIsWorkItemAvailable()
-            when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext]))
+            when(emailSender.sendEmailForDmsDocNotification(any[SendEmailDetails])(any[ExecutionContext]))
               .thenReturn(Future.successful(BadEmailRequest("Test BadEmailRequest message")))
             when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
               .thenReturn(Future.successful(true))
@@ -265,7 +266,7 @@ class SendEmailsJobSpec extends UnitSpec {
 
           def prepareTestScenario(): Unit = {
             whenThereIsWorkItemAvailable()
-            when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext])).thenReturn(Future.successful(MissingData))
+            when(emailSender.sendEmailForDmsDocNotification(any[SendEmailDetails])(any[ExecutionContext])).thenReturn(Future.successful(MissingData))
             when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
               .thenReturn(Future.successful(true))
             when(emailCancellationValidator.isEmailSendingCancelled(any[SendEmailDetails])(any)).thenReturn(Future.successful(false))
@@ -300,7 +301,7 @@ class SendEmailsJobSpec extends UnitSpec {
 
           def prepareTestScenario(): Unit = {
             whenThereIsWorkItemAvailable()
-            when(emailSender.sendEmailForDmsDocNotification(any[String])(any[ExecutionContext]))
+            when(emailSender.sendEmailForDmsDocNotification(any[SendEmailDetails])(any[ExecutionContext]))
               .thenReturn(Future.successful(InternalEmailServiceError("Test InternalEmailServiceError message")))
             when(sendEmailWorkItemRepository.markAs(any[BSONObjectID], any[ProcessingStatus with ResultStatus], any[Option[DateTime]])(any))
               .thenReturn(Future.successful(true))

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
@@ -64,7 +64,7 @@ class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
     reset(submissionRepository, unparsedNotificationWorkItemRepository, notificationRepository, notificationReceiptActionsScheduler)
 
     when(notificationRepository.insert(any)(any)).thenReturn(Future.successful(dummyWriteResultSuccess))
-    when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(submission)))
+    when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(submission)))
     when(notificationReceiptActionsScheduler.scheduleActionsExecution()).thenReturn(Cancellable.alreadyCancelled)
   }
 

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionSpec.scala
@@ -48,6 +48,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
     when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(notification))
     when(notificationRepository.insert(any)(any)).thenReturn(Future.successful(dummyWriteResultSuccess))
     when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(submission)))
+    when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission)))
   }
 
   override def afterEach(): Unit = {
@@ -82,7 +83,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
           val inOrder: InOrder = Mockito.inOrder(notificationFactory, notificationRepository, submissionRepository)
           inOrder.verify(notificationFactory).buildNotifications(any[UnparsedNotification])
           inOrder.verify(notificationRepository).insert(any[ParsedNotification])(any)
-          inOrder.verify(submissionRepository).updateMrn(any[String], any[String])
+          //inOrder.verify(submissionRepository).updateMrn(any[String], any[String])
         }
 
         "call NotificationFactory passing actionId and payload from Notification provided" in {
@@ -106,7 +107,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
 
           parseAndSaveProcess.execute(inputNotification).futureValue
 
-          verify(submissionRepository).updateMrn(eqTo(actionId), eqTo(mrn))
+          //verify(submissionRepository).updateMrn(eqTo(actionId), eqTo(mrn))
         }
       }
 
@@ -131,7 +132,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
           val inOrder: InOrder = Mockito.inOrder(notificationFactory, notificationRepository, submissionRepository)
           inOrder.verify(notificationFactory).buildNotifications(any[UnparsedNotification])
           inOrder.verify(notificationRepository, times(2)).insert(any[ParsedNotification])(any)
-          inOrder.verify(submissionRepository, times(2)).updateMrn(any[String], any[String])
+          //inOrder.verify(submissionRepository, times(2)).updateMrn(any[String], any[String])
         }
 
         "call NotificationFactory passing actionId and payload from Notification provided" in {
@@ -157,7 +158,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
 
           parseAndSaveProcess.execute(inputNotification).futureValue
 
-          verify(submissionRepository, times(2)).updateMrn(eqTo(actionId), eqTo(mrn))
+          //verify(submissionRepository, times(2)).updateMrn(eqTo(actionId), eqTo(mrn))
         }
       }
 
@@ -263,9 +264,8 @@ class ParseAndSaveActionSpec extends UnitSpec {
         val exceptionMsg = "Test Exception message"
         when(submissionRepository.updateMrn(any, any)).thenThrow(new RuntimeException(exceptionMsg))
 
-        parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue must have message exceptionMsg
+        //parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue must have message exceptionMsg
       }
     }
   }
-
 }

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionSpec.scala
@@ -47,7 +47,6 @@ class ParseAndSaveActionSpec extends UnitSpec {
 
     when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(notification))
     when(notificationRepository.insert(any)(any)).thenReturn(Future.successful(dummyWriteResultSuccess))
-    when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(submission)))
     when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission)))
   }
 
@@ -82,8 +81,8 @@ class ParseAndSaveActionSpec extends UnitSpec {
 
           val inOrder: InOrder = Mockito.inOrder(notificationFactory, notificationRepository, submissionRepository)
           inOrder.verify(notificationFactory).buildNotifications(any[UnparsedNotification])
+          inOrder.verify(submissionRepository).findByConversationId(any[String])
           inOrder.verify(notificationRepository).insert(any[ParsedNotification])(any)
-          //inOrder.verify(submissionRepository).updateMrn(any[String], any[String])
         }
 
         "call NotificationFactory passing actionId and payload from Notification provided" in {
@@ -102,12 +101,23 @@ class ParseAndSaveActionSpec extends UnitSpec {
           verify(notificationRepository).insert(eqTo(testNotification))(any)
         }
 
-        "call SubmissionRepository passing actionId and MRN provided in the Notification" in {
+        "call SubmissionRepository passing actionId in the Notification" in {
           when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(testNotification))
 
           parseAndSaveProcess.execute(inputNotification).futureValue
 
-          //verify(submissionRepository).updateMrn(eqTo(actionId), eqTo(mrn))
+          verify(submissionRepository).findByConversationId(eqTo(actionId))
+          verify(submissionRepository, never).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+        }
+
+        "call SubmissionRepository updating the MRN contained in the Notification if not already set in the Submission record" in {
+          when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission.copy(mrn = None))))
+          when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(testNotification))
+          when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(submission)))
+
+          parseAndSaveProcess.execute(inputNotification).futureValue
+
+          verify(submissionRepository).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
         }
       }
 
@@ -125,14 +135,22 @@ class ParseAndSaveActionSpec extends UnitSpec {
         }
 
         "call NotificationFactory, NotificationRepository and SubmissionRepository in order" in {
+          val inputNotification = UnparsedNotification(
+            actionId = "b1c09f1b-7c94-4e90-b754-7c5c71c55e44",
+            payload = exampleNotificationWithMultipleResponses(mrn).asXml.toString
+          )
+          val testNotifications = exampleNotificationWithMultipleResponses(mrn).asDomainModel.map { details =>
+            ParsedNotification(unparsedNotificationId = inputNotification.id, actionId = inputNotification.actionId, details = details)
+          }
+
           when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(testNotifications)
 
           parseAndSaveProcess.execute(inputNotification).futureValue
 
           val inOrder: InOrder = Mockito.inOrder(notificationFactory, notificationRepository, submissionRepository)
           inOrder.verify(notificationFactory).buildNotifications(any[UnparsedNotification])
-          inOrder.verify(notificationRepository, times(2)).insert(any[ParsedNotification])(any)
-          //inOrder.verify(submissionRepository, times(2)).updateMrn(any[String], any[String])
+          inOrder.verify(submissionRepository, times(2)).findByConversationId(any[String])
+          verify(notificationRepository, atMost(2)).insert(any[ParsedNotification])(any)
         }
 
         "call NotificationFactory passing actionId and payload from Notification provided" in {
@@ -153,12 +171,23 @@ class ParseAndSaveActionSpec extends UnitSpec {
           }
         }
 
-        "call SubmissionRepository passing actionId and MRN provided in the Notifications" in {
+        "call SubmissionRepository passing actionId in the Notifications" in {
           when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(testNotifications)
 
           parseAndSaveProcess.execute(inputNotification).futureValue
 
-          //verify(submissionRepository, times(2)).updateMrn(eqTo(actionId), eqTo(mrn))
+          verify(submissionRepository, times(2)).findByConversationId(eqTo(actionId))
+          verify(submissionRepository, never).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+        }
+
+        "call SubmissionRepository updating the MRN contained in the Notification if not already set in the Submission record" in {
+          when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission.copy(mrn = None))))
+          when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(testNotifications)
+          when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(submission)))
+
+          parseAndSaveProcess.execute(inputNotification).futureValue
+
+          verify(submissionRepository, times(2)).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
         }
       }
 
@@ -194,6 +223,37 @@ class ParseAndSaveActionSpec extends UnitSpec {
           parseAndSaveProcess.execute(inputNotification).futureValue
 
           verifyNoInteractions(submissionRepository)
+        }
+      }
+
+      "has a Submission record associated" that {
+        val inputNotification = UnparsedNotification(actionId = actionId, payload = exampleRejectNotification(mrn).asXml.toString)
+        val testNotification = ParsedNotification(
+          unparsedNotificationId = inputNotification.id,
+          actionId = inputNotification.actionId,
+          details = exampleRejectNotification(mrn).asDomainModel.head
+        )
+
+        "does not have an MRN value set" should {
+          "update the submission record's MRN value" in {
+            val noMrnSubmission = submission.copy(mrn = None)
+            when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(noMrnSubmission)))
+            when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(noMrnSubmission)))
+            when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(testNotification))
+
+            parseAndSaveProcess.execute(inputNotification).futureValue
+
+          }
+        }
+
+        "does have an MRN value set" should {
+          "not update the submission record's MRN value" in {
+            when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission)))
+            when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(testNotification))
+
+            parseAndSaveProcess.execute(inputNotification).futureValue
+            verify(submissionRepository, never).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+          }
         }
       }
     }
@@ -237,34 +297,65 @@ class ParseAndSaveActionSpec extends UnitSpec {
 
         parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue must have message exceptionMsg
       }
-
-      "not call SubmissionRepository" in {
-        val exceptionMsg = "Test Exception message"
-        when(notificationRepository.insert(any)(any))
-          .thenReturn(Future.failed(dummyWriteResultFailure(exceptionMsg)))
-
-        parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue
-
-        verifyNoInteractions(submissionRepository)
-      }
     }
 
     "SubmissionRepository on updateMrn returns empty Option" should {
 
-      "result in a success" in {
-        when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(None))
+      "result in throwing a NotificationProcessingException" in {
+        when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission.copy(mrn = None))))
+        when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(None))
 
-        parseAndSaveProcess.execute(notificationUnparsed).futureValue must equal((): Unit)
+        val throwable = parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue
+        throwable.getMessage mustBe "No submission record was found for received notification!"
+
+        verifyNoInteractions(notificationRepository)
       }
     }
 
-    "SubmissionRepository on updateMrn throws an Exception" should {
+    "SubmissionRepository on findByConversationId" that {
+      "returns a None" should {
+        "not then call the NotificationRepository" in {
+          when(submissionRepository.findByConversationId(any))
+            .thenReturn(Future.successful(None))
 
-      "return failed Future" in {
-        val exceptionMsg = "Test Exception message"
-        when(submissionRepository.updateMrn(any, any)).thenThrow(new RuntimeException(exceptionMsg))
+          val throwable = parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue
+          throwable.getMessage mustBe "No submission record was found for received notification!"
 
-        //parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue must have message exceptionMsg
+          verifyNoInteractions(notificationRepository)
+        }
+      }
+
+      "throws an Exception" should {
+        "not then call the NotificationRepository" in {
+          val exceptionMsg = "Test Exception message"
+          when(submissionRepository.findByConversationId(any))
+            .thenReturn(Future.failed(dummyWriteResultFailure(exceptionMsg)))
+
+          parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue
+
+          verifyNoInteractions(notificationRepository)
+        }
+      }
+    }
+
+    "SubmissionRepository on updateMrn" that {
+      "returns WriteResult with Error" should {
+        "not then call the NotificationRepository" in {
+          val exceptionMsg = "Test Exception message"
+          when(submissionRepository.setMrnIfMissing(any, any))
+            .thenReturn(Future.failed(dummyWriteResultFailure(exceptionMsg)))
+
+          verifyNoInteractions(notificationRepository)
+        }
+      }
+
+      "returns a None" should {
+        "not then call the NotificationRepository" in {
+          when(submissionRepository.setMrnIfMissing(any, any))
+            .thenReturn(Future.successful(None))
+
+          verifyNoInteractions(notificationRepository)
+        }
       }
     }
   }

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocActionSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/SendEmailForDmsDocActionSpec.scala
@@ -66,7 +66,8 @@ class SendEmailForDmsDocActionSpec extends UnitSpec {
       val testNotification = notification.copy(details = notification.details.copy(status = SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED))
       val testActionId = testNotification.actionId
 
-      val testSendEmailDetails = SendEmailDetails(notificationId = testNotification._id, mrn = testNotification.details.mrn)
+      val testSendEmailDetails =
+        SendEmailDetails(notificationId = testNotification._id, mrn = testNotification.details.mrn, actionId = testNotification.actionId)
       val testWorkItem = WorkItem(
         id = BSONObjectID.generate,
         receivedAt = DateTime.now,

--- a/test/util/testdata/WorkItemTestData.scala
+++ b/test/util/testdata/WorkItemTestData.scala
@@ -24,7 +24,8 @@ import uk.gov.hmrc.workitem.{ProcessingStatus, WorkItem}
 
 object WorkItemTestData {
 
-  def buildTestSendEmailDetails: SendEmailDetails = SendEmailDetails(notificationId = BSONObjectID.generate, mrn = ExportsTestData.mrn)
+  def buildTestSendEmailDetails: SendEmailDetails =
+    SendEmailDetails(notificationId = BSONObjectID.generate, mrn = ExportsTestData.mrn, actionId = "actionId")
 
   def buildTestSendEmailWorkItem(status: ProcessingStatus, updatedAt: DateTime = now, availableAt: DateTime = now): WorkItem[SendEmailDetails] =
     buildTestWorkItem(status, updatedAt, availableAt, item = buildTestSendEmailDetails)
@@ -39,5 +40,4 @@ object WorkItemTestData {
       failureCount = 0,
       item = item
     )
-
 }


### PR DESCRIPTION
Removed from sumbmissions collection: ‘eoriIdx’ & ‘updateTimeIdx’
Removed from notifications collection: ‘actionIdIdx’, ‘detailsDateTimeIssuedIdx’ &  'detailsMrnIdx' 

Added new 'actionId' field to SendEmailDetails entity (with DB migration of existing records).

Reworked the declaration submission process to pair down number of queries performed from 6 -> 2.
Reworked the parse notification process to only update the submission's 'mrn' field if it has not
already been set.

When parsing notifications ensure that if no associated submission can be updated
that the parsing of the notification is considered as a failure. This is to prevent
the unlikely scenario of a notification being received and parsed before the
associated submission record is inserted on declaration submission.

Schedule notification reattempt every 60 seconds (in case of failure scenario above).
