### PR TITLE
[CEDS-3784] Optimisation bug fix

### DIFF
--- a/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
@@ -67,8 +67,8 @@ class SubmissionRepository @Inject()(implicit mc: ReactiveMongoComponent, ec: Ex
     submission
   }
 
-  def setMrnIfMissing(conversationId: String, newMrn: String): Future[Option[Submission]] = {
-    val query = Json.obj("actions.id" -> conversationId, "mrn" -> Json.obj("$exists" -> false))
+  def updateMrn(conversationId: String, newMrn: String): Future[Option[Submission]] = {
+    val query = Json.obj("actions.id" -> conversationId)
     val update = Json.obj("$set" -> Json.obj("mrn" -> newMrn))
     performUpdate(query, update)
   }

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveAction.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveAction.scala
@@ -58,7 +58,7 @@ class ParseAndSaveAction @Inject()(
       .flatMap { maybeSubmission =>
         maybeSubmission match {
           case Some(Submission(_, _, _, None, _, _)) =>
-            submissionRepository.setMrnIfMissing(notification.actionId, notification.details.mrn)
+            submissionRepository.updateMrn(notification.actionId, notification.details.mrn)
           case _ =>
             Future.successful(maybeSubmission)
         }

--- a/test/it/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
+++ b/test/it/uk/gov/hmrc/exports/repositories/SubmissionRepositorySpec.scala
@@ -84,18 +84,7 @@ class SubmissionRepositorySpec extends IntegrationTestBaseSpec {
     "return empty Option" when {
       "there is no Submission with given ConversationId" in {
         val newMrn = mrn_2
-        repo.setMrnIfMissing(actionId, newMrn).futureValue mustNot be(defined)
-      }
-
-      "there is a Submission containing Action with given ConversationId and MRN is Some" in {
-        repo.save(submission).futureValue
-
-        val updatedSubmission = repo.setMrnIfMissing(actionId, mrn_2).futureValue
-
-        updatedSubmission.isDefined mustBe false
-
-        val submissionRecord = repo.findBy(eori, SubmissionQueryParameters(uuid = Some(submission.uuid))).futureValue
-        submissionRecord.head.mrn mustBe submission.mrn
+        repo.updateMrn(actionId, newMrn).futureValue mustNot be(defined)
       }
     }
 
@@ -105,7 +94,7 @@ class SubmissionRepositorySpec extends IntegrationTestBaseSpec {
         val newMrn = mrn_2
         val expectedUpdatedSubmission = submission.copy(mrn = Some(newMrn))
 
-        val updatedSubmission = repo.setMrnIfMissing(actionId, newMrn).futureValue
+        val updatedSubmission = repo.updateMrn(actionId, newMrn).futureValue
 
         updatedSubmission.value must equal(expectedUpdatedSubmission)
       }

--- a/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
+++ b/test/unit/uk/gov/hmrc/exports/base/UnitTestMockBuilder.scala
@@ -51,7 +51,7 @@ object UnitTestMockBuilder extends MockitoSugar {
     when(submissionRepositoryMock.addAction(any[Submission](), any())).thenReturn(Future.successful(mock[Submission]))
     when(submissionRepositoryMock.findBy(any(), any())).thenReturn(Future.successful(Seq.empty))
     when(submissionRepositoryMock.save(any())).thenReturn(Future.successful(mock[Submission]))
-    when(submissionRepositoryMock.setMrnIfMissing(any(), any())).thenReturn(Future.successful(None))
+    when(submissionRepositoryMock.updateMrn(any(), any())).thenReturn(Future.successful(None))
     submissionRepositoryMock
   }
 

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -140,7 +140,7 @@ class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with
         actionGenerated.id mustBe "conv-id"
         actionGenerated.requestType mustBe SubmissionRequest
 
-        verify(submissionRepository, never).setMrnIfMissing(any[String], any[String])
+        verify(submissionRepository, never).updateMrn(any[String], any[String])
         verify(sendEmailForDmsDocAction, never).execute(any[String])
       }
     }

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
@@ -64,7 +64,7 @@ class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
     reset(submissionRepository, unparsedNotificationWorkItemRepository, notificationRepository, notificationReceiptActionsScheduler)
 
     when(notificationRepository.insert(any)(any)).thenReturn(Future.successful(dummyWriteResultSuccess))
-    when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(submission)))
+    when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(submission)))
     when(notificationReceiptActionsScheduler.scheduleActionsExecution()).thenReturn(Cancellable.alreadyCancelled)
   }
 

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionSpec.scala
@@ -107,17 +107,17 @@ class ParseAndSaveActionSpec extends UnitSpec {
           parseAndSaveProcess.execute(inputNotification).futureValue
 
           verify(submissionRepository).findByConversationId(eqTo(actionId))
-          verify(submissionRepository, never).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+          verify(submissionRepository, never).updateMrn(eqTo(actionId), eqTo(mrn))
         }
 
         "call SubmissionRepository updating the MRN contained in the Notification if not already set in the Submission record" in {
           when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission.copy(mrn = None))))
           when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(testNotification))
-          when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(submission)))
+          when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(submission)))
 
           parseAndSaveProcess.execute(inputNotification).futureValue
 
-          verify(submissionRepository).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+          verify(submissionRepository).updateMrn(eqTo(actionId), eqTo(mrn))
         }
       }
 
@@ -177,17 +177,17 @@ class ParseAndSaveActionSpec extends UnitSpec {
           parseAndSaveProcess.execute(inputNotification).futureValue
 
           verify(submissionRepository, times(2)).findByConversationId(eqTo(actionId))
-          verify(submissionRepository, never).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+          verify(submissionRepository, never).updateMrn(eqTo(actionId), eqTo(mrn))
         }
 
         "call SubmissionRepository updating the MRN contained in the Notification if not already set in the Submission record" in {
           when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission.copy(mrn = None))))
           when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(testNotifications)
-          when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(submission)))
+          when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(submission)))
 
           parseAndSaveProcess.execute(inputNotification).futureValue
 
-          verify(submissionRepository, times(2)).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+          verify(submissionRepository, times(2)).updateMrn(eqTo(actionId), eqTo(mrn))
         }
       }
 
@@ -238,7 +238,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
           "update the submission record's MRN value" in {
             val noMrnSubmission = submission.copy(mrn = None)
             when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(noMrnSubmission)))
-            when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(Some(noMrnSubmission)))
+            when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(Some(noMrnSubmission)))
             when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(testNotification))
 
             parseAndSaveProcess.execute(inputNotification).futureValue
@@ -252,7 +252,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
             when(notificationFactory.buildNotifications(any[UnparsedNotification])).thenReturn(Seq(testNotification))
 
             parseAndSaveProcess.execute(inputNotification).futureValue
-            verify(submissionRepository, never).setMrnIfMissing(eqTo(actionId), eqTo(mrn))
+            verify(submissionRepository, never).updateMrn(eqTo(actionId), eqTo(mrn))
           }
         }
       }
@@ -303,7 +303,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
 
       "result in throwing a NotificationProcessingException" in {
         when(submissionRepository.findByConversationId(any)).thenReturn(Future.successful(Some(submission.copy(mrn = None))))
-        when(submissionRepository.setMrnIfMissing(any, any)).thenReturn(Future.successful(None))
+        when(submissionRepository.updateMrn(any, any)).thenReturn(Future.successful(None))
 
         val throwable = parseAndSaveProcess.execute(notificationUnparsed).failed.futureValue
         throwable.getMessage mustBe "No submission record was found for received notification!"
@@ -342,7 +342,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
       "returns WriteResult with Error" should {
         "not then call the NotificationRepository" in {
           val exceptionMsg = "Test Exception message"
-          when(submissionRepository.setMrnIfMissing(any, any))
+          when(submissionRepository.updateMrn(any, any))
             .thenReturn(Future.failed(dummyWriteResultFailure(exceptionMsg)))
 
           verifyNoInteractions(notificationRepository)
@@ -351,7 +351,7 @@ class ParseAndSaveActionSpec extends UnitSpec {
 
       "returns a None" should {
         "not then call the NotificationRepository" in {
-          when(submissionRepository.setMrnIfMissing(any, any))
+          when(submissionRepository.updateMrn(any, any))
             .thenReturn(Future.successful(None))
 
           verifyNoInteractions(notificationRepository)


### PR DESCRIPTION
There was a bug where as the fetching of the submission record happened for each notification before any of the
conditional updates occur, this resulted in the first update being successful but all the subsequent
updates failing (due to its condition no longer being satisfied).

I've removed the condition on the update which will mean unnecessary MRN updates happening for now. Will come bakc to this for
a better solution later.