### PR TITLE
[CEDS-3784] Further optimisations

### DIFF
--- a/test/util/testdata/RepositoryTestData.scala
+++ b/test/util/testdata/RepositoryTestData.scala
@@ -16,7 +16,7 @@
 
 package testdata
 
-import reactivemongo.api.commands.{LastError, WriteResult}
+import reactivemongo.api.commands.{LastError, MultiBulkWriteResult, WriteResult}
 
 import scala.util.control.NoStackTrace
 
@@ -24,6 +24,9 @@ object RepositoryTestData {
 
   val dummyWriteResultSuccess: WriteResult =
     LastError(true, None, None, None, 0, None, false, None, None, false, None, None)
+
+  val dummyMultiBulkWriteResultSuccess: MultiBulkWriteResult =
+    MultiBulkWriteResult(dummyWriteResultSuccess)
 
   def dummyWriteResultFailure(exceptionMessage: String = "Test Exception message"): RuntimeException =
     new RuntimeException(exceptionMessage) with NoStackTrace


### PR DESCRIPTION
Instead of performing for each notification:
* a find query & optional update query on submission collection
* plus an insert into the notifications collection

We now perform just a single query & optional update query on submission collection
that covers all notifications (as all notifications share the same actionId when
received in a single endpoint call), and a single bulk insert operation that covers
all notifications being processed.