### PR TITLE
CEDS-3854 notification date time parsing bug

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/testonly/GenerateSubmittedDecController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/testonly/GenerateSubmittedDecController.scala
@@ -27,7 +27,7 @@ import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.{ACCE
 import uk.gov.hmrc.exports.repositories.{DeclarationRepository, ParsedNotificationRepository, SubmissionRepository}
 import uk.gov.hmrc.exports.util.ExportsDeclarationBuilder
 
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
+import java.time.{ZoneId, ZonedDateTime}
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -85,12 +85,8 @@ object GenerateSubmittedDecController extends ExportsDeclarationBuilder {
   def createNotification(declaration: ExportsDeclaration, status: SubmissionStatus = ACCEPTED) = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID(),
     actionId = UUID.randomUUID().toString,
-    details = NotificationDetails(
-      declaration.consignmentReferences.flatMap(_.mrn).getOrElse(""),
-      ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("UTC")),
-      status,
-      Seq.empty
-    )
+    details =
+      NotificationDetails(declaration.consignmentReferences.flatMap(_.mrn).getOrElse(""), ZonedDateTime.now(ZoneId.of("UTC")), status, Seq.empty)
   )
 
   def createDeclaration()(implicit request: Request[CreateSubmitDecDocumentsRequest]) = aDeclaration(

--- a/app/uk/gov/hmrc/exports/models/ead/parsers/DateParser.scala
+++ b/app/uk/gov/hmrc/exports/models/ead/parsers/DateParser.scala
@@ -16,15 +16,15 @@
 
 package uk.gov.hmrc.exports.models.ead.parsers
 
+import java.time.{ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 
 object DateParser {
 
-  val formatter304: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssz")
+  val formatter304: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
   val zoneUTC: ZoneId = ZoneId.of("UTC")
 
-  def zonedDateTime(datetime: String): ZonedDateTime = ZonedDateTime.of(LocalDateTime.parse(datetime, formatter304), zoneUTC)
+  def zonedDateTime(datetime: String): ZonedDateTime = ZonedDateTime.parse(datetime, formatter304)
 
   def optionZonedDateTime(datetime: String): Option[ZonedDateTime] = if (datetime.nonEmpty) Some(zonedDateTime(datetime)) else None
 }

--- a/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
@@ -16,28 +16,27 @@
 
 package uk.gov.hmrc.exports.services.notifications
 
-import java.time.format.DateTimeFormatter
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
-
 import play.api.Logger
+import uk.gov.hmrc.exports.models.{Pointer, PointerSection, PointerSectionType}
 import uk.gov.hmrc.exports.models.declaration.notifications.{NotificationDetails, NotificationError}
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
-import uk.gov.hmrc.exports.models.{Pointer, PointerSection, PointerSectionType}
 
+import java.time.format.DateTimeFormatter
+import java.time.{ZonedDateTime, ZoneId}
 import scala.xml.{Node, NodeSeq}
 
 class NotificationParser {
 
   private val logger = Logger(this.getClass)
 
+  private val formatter304 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
+
   def parse(notificationXml: NodeSeq): Seq[NotificationDetails] = {
     val responsesXml = notificationXml \ "Response"
 
     responsesXml.map { singleResponseXml =>
       val mrn = (singleResponseXml \ "Declaration" \ "ID").text
-      val formatter304 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
-      val dateTimeIssued =
-        ZonedDateTime.of(LocalDateTime.parse((singleResponseXml \ "IssueDateTime" \ "DateTimeString").text, formatter304), ZoneId.of("UTC"))
+      val dateTimeIssued = ZonedDateTime.parse((singleResponseXml \ "IssueDateTime" \ "DateTimeString").text, formatter304)
       val functionCode = (singleResponseXml \ "FunctionCode").text
 
       val nameCode =
@@ -47,7 +46,7 @@ class NotificationParser {
 
       val errors = buildErrors(singleResponseXml)
 
-      NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = SubmissionStatus.retrieve(functionCode, nameCode), errors = errors)
+      NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued.withZoneSameInstant(ZoneId.of("UTC")), status = SubmissionStatus.retrieve(functionCode, nameCode), errors = errors)
     }
   }
 

--- a/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.exports.models.declaration.notifications.{NotificationDetails
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
 
 import java.time.format.DateTimeFormatter
-import java.time.{ZonedDateTime, ZoneId}
+import java.time.{ZoneId, ZonedDateTime}
 import scala.xml.{Node, NodeSeq}
 
 class NotificationParser {
@@ -46,7 +46,12 @@ class NotificationParser {
 
       val errors = buildErrors(singleResponseXml)
 
-      NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued.withZoneSameInstant(ZoneId.of("UTC")), status = SubmissionStatus.retrieve(functionCode, nameCode), errors = errors)
+      NotificationDetails(
+        mrn = mrn,
+        dateTimeIssued = dateTimeIssued.withZoneSameInstant(ZoneId.of("UTC")),
+        status = SubmissionStatus.retrieve(functionCode, nameCode),
+        errors = errors
+      )
     }
   }
 

--- a/app/uk/gov/hmrc/exports/util/ExportsDeclarationBuilder.scala
+++ b/app/uk/gov/hmrc/exports/util/ExportsDeclarationBuilder.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.exports.models.declaration.DeclarationStatus.DeclarationStatu
 import uk.gov.hmrc.exports.models.DeclarationType.DeclarationType
 import uk.gov.hmrc.exports.models.declaration._
 
-import java.time.{Instant, LocalDateTime, ZoneOffset}
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
 
 //noinspection ScalaStyle
 trait ExportsDeclarationBuilder extends ExportsItemBuilder {
@@ -43,8 +43,8 @@ trait ExportsDeclarationBuilder extends ExportsItemBuilder {
     id = uuid,
     eori = "eori",
     status = DeclarationStatus.COMPLETE,
-    createdDateTime = LocalDateTime.of(2019, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC),
-    updatedDateTime = LocalDateTime.of(2019, 2, 2, 0, 0, 0).toInstant(ZoneOffset.UTC),
+    createdDateTime = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
+    updatedDateTime = ZonedDateTime.of(2019, 2, 2, 0, 0, 0, 0, ZoneOffset.UTC).toInstant,
     sourceId = None,
     `type` = DeclarationType.STANDARD,
     dispatchLocation = None,
@@ -335,7 +335,7 @@ trait ExportsDeclarationBuilder extends ExportsItemBuilder {
     )
 
   def withUpdateDate(year: Int, month: Int, dayOfMonth: Int): ExportsDeclarationModifier =
-    _.copy(updatedDateTime = LocalDateTime.of(year, month, dayOfMonth, 10, 0, 0).toInstant(ZoneOffset.UTC))
+    _.copy(updatedDateTime = ZonedDateTime.of(year, month, dayOfMonth, 10, 0, 0, 0, ZoneOffset.UTC).toInstant)
 
   def withMUCR(mucr: String): ExportsDeclarationModifier =
     cache => cache.copy(linkDucrToMucr = Some(YesNoAnswer.yes), mucr = Some(MUCR(mucr)))
@@ -343,6 +343,6 @@ trait ExportsDeclarationBuilder extends ExportsItemBuilder {
   def withReadyForSubmission(): ExportsDeclarationModifier =
     declaration => declaration.copy(readyForSubmission = Some(true))
 
-  def withUpdatedDateTime(updatedDateTime: Instant = LocalDateTime.now().toInstant(ZoneOffset.UTC)): ExportsDeclarationModifier =
+  def withUpdatedDateTime(updatedDateTime: Instant = Instant.now()): ExportsDeclarationModifier =
     declaration => declaration.copy(updatedDateTime = updatedDateTime)
 }

--- a/test/unit/uk/gov/hmrc/exports/models/declaration/notifications/ParsedNotificationSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/models/declaration/notifications/ParsedNotificationSpec.scala
@@ -21,8 +21,8 @@ import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.exports.base.UnitSpec
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
 
+import java.time.{ZoneId, ZonedDateTime}
 import java.time.format.DateTimeFormatter
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import java.util.UUID
 
 class ParsedNotificationSpec extends UnitSpec {
@@ -33,20 +33,20 @@ class ParsedNotificationSpec extends UnitSpec {
     val id = BSONObjectID.generate
     val unparsedNotificationId = UUID.randomUUID()
     val actionId = "123"
-    val dateTime = LocalDateTime.now()
+    val dateTime = ZonedDateTime.now(ZoneId.of("UCT"))
     val mrn = "id1"
 
     val notification = ParsedNotification(
       _id = id,
       unparsedNotificationId,
       actionId = actionId,
-      details = NotificationDetails(mrn, ZonedDateTime.of(dateTime, ZoneId.of("UCT")), SubmissionStatus.ACCEPTED, Seq.empty)
+      details = NotificationDetails(mrn, dateTime, SubmissionStatus.ACCEPTED, Seq.empty)
     )
 
     "have json writes that produce object which could be parsed by the front end service" in {
       val json = Json.toJson(notification)(ParsedNotification.FrontendFormat.writes)
 
-      json.toString() mustBe ParsedNotificationSpec.serialisedWithFrontendFormat(actionId, mrn, dateTime.atZone(ZoneId.of("UCT")).format(formatter))
+      json.toString() mustBe ParsedNotificationSpec.serialisedWithFrontendFormat(actionId, mrn, dateTime.format(formatter))
     }
 
     "have json writes that produce object which could be parsed by the database" in {
@@ -57,7 +57,7 @@ class ParsedNotificationSpec extends UnitSpec {
         unparsedNotificationId.toString,
         actionId,
         mrn,
-        dateTime.atZone(ZoneId.of("UCT")).format(formatter)
+        dateTime.format(formatter)
       )
     }
   }

--- a/test/unit/uk/gov/hmrc/exports/models/ead/MrnStatusSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/models/ead/MrnStatusSpec.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.exports.models.ead
 
-import java.time.{LocalDateTime, ZonedDateTime}
+import uk.gov.hmrc.exports.models.ead.parsers.DateParser.formatter304
 
-import uk.gov.hmrc.exports.models.ead.parsers.DateParser.{formatter304, zoneUTC}
+import java.time.ZonedDateTime
 
 object MrnStatusSpec {
   val completeMrnStatus = MrnStatus(
@@ -27,10 +27,10 @@ object MrnStatusSpec {
     eori = "GB123456789012000",
     declarationType = "IMZ",
     ucr = Some("20GBAKZ81EQJ2WXYZ"),
-    receivedDateTime = ZonedDateTime.of(LocalDateTime.parse("20190702110700Z", formatter304), zoneUTC),
-    releasedDateTime = Some(ZonedDateTime.of(LocalDateTime.parse("20190702110700Z", formatter304), zoneUTC)),
-    acceptanceDateTime = Some(ZonedDateTime.of(LocalDateTime.parse("20190702110700Z", formatter304), zoneUTC)),
-    createdDateTime = ZonedDateTime.of(LocalDateTime.parse("20200310011300Z", formatter304), zoneUTC),
+    receivedDateTime = ZonedDateTime.parse("20190702110700Z", formatter304),
+    releasedDateTime = Some(ZonedDateTime.parse("20190702110700Z", formatter304)),
+    acceptanceDateTime = Some(ZonedDateTime.parse("20190702110700Z", formatter304)),
+    createdDateTime = ZonedDateTime.parse("20200310011300Z", formatter304),
     roe = "6",
     ics = "15",
     irc = Some("000"),

--- a/test/unit/uk/gov/hmrc/exports/models/ead/parsers/MrnStatusParserSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/models/ead/parsers/MrnStatusParserSpec.scala
@@ -30,9 +30,9 @@ class MrnStatusParserSpec extends UnitSpec {
       mrnStatus.eori mustBe "GB123456789012000"
       mrnStatus.versionId mustBe "1"
       mrnStatus.declarationType mustBe "IMZ"
-      mrnStatus.acceptanceDateTime mustBe Some(ZonedDateTime.of(2019, 1, 2, 11, 7, 57, 0, DateParser.zoneUTC))
-      mrnStatus.receivedDateTime mustBe ZonedDateTime.of(2019, 7, 2, 11, 8, 57, 0, DateParser.zoneUTC)
-      mrnStatus.releasedDateTime mustBe Some(ZonedDateTime.of(2019, 7, 2, 13, 9, 57, 0, DateParser.zoneUTC))
+      mrnStatus.acceptanceDateTime.map(_.isEqual(ZonedDateTime.of(2019, 1, 2, 11, 7, 57, 0, DateParser.zoneUTC))) mustBe Some(true)
+      mrnStatus.receivedDateTime.isEqual(ZonedDateTime.of(2019, 7, 2, 11, 8, 57, 0, DateParser.zoneUTC)) mustBe true
+      mrnStatus.releasedDateTime.map(_.isEqual(ZonedDateTime.of(2019, 7, 2, 13, 9, 57, 0, DateParser.zoneUTC))) mustBe Some(true)
       mrnStatus.createdDateTime mustNot be(None)
       mrnStatus.roe mustBe "6"
       mrnStatus.ics mustBe "15"
@@ -60,7 +60,7 @@ class MrnStatusParserSpec extends UnitSpec {
       mrnStatus.versionId mustBe "1"
       mrnStatus.declarationType mustBe "EXD"
       mrnStatus.acceptanceDateTime mustBe None
-      mrnStatus.receivedDateTime mustBe ZonedDateTime.of(2020, 2, 27, 11, 43, 5, 0, DateParser.zoneUTC)
+      mrnStatus.receivedDateTime.isEqual(ZonedDateTime.of(2020, 2, 27, 11, 43, 5, 0, DateParser.zoneUTC)) mustBe true
       mrnStatus.releasedDateTime mustBe None
       mrnStatus.createdDateTime mustNot be(None)
       mrnStatus.roe mustBe "H"
@@ -79,7 +79,7 @@ class MrnStatusParserSpec extends UnitSpec {
       mrnStatus.versionId mustBe "1"
       mrnStatus.declarationType mustBe "EXD"
       mrnStatus.acceptanceDateTime mustBe None
-      mrnStatus.receivedDateTime mustBe ZonedDateTime.of(2020, 2, 27, 11, 43, 5, 0, DateParser.zoneUTC)
+      mrnStatus.receivedDateTime.isEqual(ZonedDateTime.of(2020, 2, 27, 11, 43, 5, 0, DateParser.zoneUTC)) mustBe true
       mrnStatus.releasedDateTime mustBe None
       mrnStatus.createdDateTime mustNot be(None)
       mrnStatus.roe mustBe "H"

--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/EmailCancellationValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/EmailCancellationValidatorSpec.scala
@@ -54,7 +54,7 @@ class EmailCancellationValidatorSpec extends UnitSpec {
   "EmailSendingValidator on isEmailSendingCancelled" should {
 
     val zone: ZoneId = ZoneId.of("Europe/London")
-    val firstDate = ZonedDateTime.of(LocalDateTime.of(2020, 6, 1, 10, 10), zone)
+    val firstDate = ZonedDateTime.of(2020, 6, 1, 10, 10, 0, 0, zone)
 
     val dmsDocNotification = createNotification(firstDate, ADDITIONAL_DOCUMENTS_REQUIRED)
     val sendEmailDetails =

--- a/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/SubmissionServiceSpec.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.exports.util.ExportsDeclarationBuilder
 import uk.gov.hmrc.http.HeaderCarrier
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
 
-import java.time.{LocalDateTime, ZoneOffset, ZonedDateTime}
+import java.time.{ZoneOffset, ZonedDateTime}
 import scala.concurrent.{ExecutionContext, Future}
 
 class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with MockMetrics {
@@ -112,7 +112,7 @@ class SubmissionServiceSpec extends UnitSpec with ExportsDeclarationBuilder with
     "submit to the Dec API" when {
       val declaration = aDeclaration()
 
-      val dateTimeIssued = ZonedDateTime.of(LocalDateTime.now(), ZoneOffset.UTC)
+      val dateTimeIssued = ZonedDateTime.now(ZoneOffset.UTC)
 
       val newAction = Action(id = "conv-id", requestType = SubmissionRequest, requestTimestamp = dateTimeIssued)
 

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
@@ -21,9 +21,25 @@ import testdata.notifications.ExampleXmlAndNotificationDetailsPair._
 import uk.gov.hmrc.exports.base.UnitSpec
 import uk.gov.hmrc.exports.models.declaration.notifications.NotificationDetails
 
+import java.time.ZonedDateTime
+
 class NotificationParserSpec extends UnitSpec {
 
   private val notificationParser = new NotificationParser()
+
+  private def compareNotificationSequences(actual: Seq[NotificationDetails], expected: Seq[NotificationDetails]) = {
+    actual.size mustBe expected.size
+
+    val actualVsExpected = actual.zip(expected)
+    actualVsExpected.foreach { case (actual, expected) =>
+      actual.mrn mustBe expected.mrn
+      actual.status mustBe expected.status
+      withClue(s"Check if actual '${actual.dateTimeIssued.toInstant()}' is equal to expected '${expected.dateTimeIssued.toInstant()}'?") {
+        actual.dateTimeIssued.toInstant().equals(expected.dateTimeIssued.toInstant()) mustBe true
+      }
+      actual.errors mustBe expected.errors
+    }
+  }
 
   "NotificationParser on parse" when {
 
@@ -47,7 +63,7 @@ class NotificationParserSpec extends UnitSpec {
 
           val result = notificationParser.parse(testNotification.asXml)
 
-          result mustBe testNotification.asDomainModel
+          compareNotificationSequences(result, testNotification.asDomainModel)
         }
       }
 
@@ -58,7 +74,7 @@ class NotificationParserSpec extends UnitSpec {
 
           val result = notificationParser.parse(testNotification.asXml)
 
-          result mustBe testNotification.asDomainModel
+          compareNotificationSequences(result, testNotification.asDomainModel)
         }
       }
 
@@ -68,7 +84,7 @@ class NotificationParserSpec extends UnitSpec {
 
           val result = notificationParser.parse(testNotification.asXml)
 
-          result mustBe testNotification.asDomainModel
+          compareNotificationSequences(result, testNotification.asDomainModel)
         }
       }
     }
@@ -80,7 +96,7 @@ class NotificationParserSpec extends UnitSpec {
 
         val result = notificationParser.parse(testNotification.asXml)
 
-        result mustBe testNotification.asDomainModel
+        compareNotificationSequences(result, testNotification.asDomainModel)
       }
     }
 
@@ -92,6 +108,33 @@ class NotificationParserSpec extends UnitSpec {
         an[Exception] mustBe thrownBy(notificationParser.parse(testNotification.asXml))
       }
     }
-  }
 
+    "provided with notification with a IssueDateTime value " should {
+      "correctly parse the dateTime to a UTC value" when {
+        "it contains an offset value of +00 (UTC)" in {
+          val testNotification = exampleReceivedNotification(mrn, ZonedDateTime.from(formatter304.parse("20221231235959+00")))
+
+          val result = notificationParser.parse(testNotification.asXml)
+
+          compareNotificationSequences(result, testNotification.asDomainModel)
+        }
+
+        "it contains an offset value of +01 (BST)" in {
+          val testNotification = exampleReceivedNotification(mrn, ZonedDateTime.from(formatter304.parse("20221231235959+01")))
+
+          val result = notificationParser.parse(testNotification.asXml)
+
+          compareNotificationSequences(result, testNotification.asDomainModel)
+        }
+
+        "it contains an offset value of -01 " in {
+          val testNotification = exampleReceivedNotification(mrn, ZonedDateTime.from(formatter304.parse("20221231235959-01")))
+
+          val result = notificationParser.parse(testNotification.asXml)
+
+          compareNotificationSequences(result, testNotification.asDomainModel)
+        }
+      }
+    }
+  }
 }

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
@@ -31,13 +31,14 @@ class NotificationParserSpec extends UnitSpec {
     actual.size mustBe expected.size
 
     val actualVsExpected = actual.zip(expected)
-    actualVsExpected.foreach { case (actual, expected) =>
-      actual.mrn mustBe expected.mrn
-      actual.status mustBe expected.status
-      withClue(s"Check if actual '${actual.dateTimeIssued.toInstant()}' is equal to expected '${expected.dateTimeIssued.toInstant()}'?") {
-        actual.dateTimeIssued.toInstant().equals(expected.dateTimeIssued.toInstant()) mustBe true
-      }
-      actual.errors mustBe expected.errors
+    actualVsExpected.foreach {
+      case (actual, expected) =>
+        actual.mrn mustBe expected.mrn
+        actual.status mustBe expected.status
+        withClue(s"Check if actual '${actual.dateTimeIssued.toInstant()}' is equal to expected '${expected.dateTimeIssued.toInstant()}'?") {
+          actual.dateTimeIssued.toInstant().equals(expected.dateTimeIssued.toInstant()) mustBe true
+        }
+        actual.errors mustBe expected.errors
     }
   }
 

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
@@ -16,17 +16,11 @@
 
 package uk.gov.hmrc.exports.services.notifications
 
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
-import java.util.UUID
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
 import akka.actor.Cancellable
 import org.joda.time.DateTime
+import org.mockito.{ArgumentCaptor, InOrder, Mockito}
 import org.mockito.ArgumentMatchersSugar.{any, eqTo}
 import org.mockito.Mockito._
-import org.mockito.{ArgumentCaptor, InOrder, Mockito}
 import org.scalatest.concurrent.IntegrationPatience
 import reactivemongo.bson.BSONObjectID
 import testdata.ExportsTestData._
@@ -37,11 +31,16 @@ import testdata.notifications.NotificationTestData._
 import uk.gov.hmrc.exports.base.UnitSpec
 import uk.gov.hmrc.exports.base.UnitTestMockBuilder._
 import uk.gov.hmrc.exports.models.declaration.notifications.{NotificationDetails, ParsedNotification, UnparsedNotification}
-import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.ACCEPTED
 import uk.gov.hmrc.exports.models.declaration.submissions._
+import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus.ACCEPTED
 import uk.gov.hmrc.exports.repositories.{ParsedNotificationRepository, SubmissionRepository, UnparsedNotificationWorkItemRepository}
 import uk.gov.hmrc.exports.services.notifications.receiptactions.NotificationReceiptActionsScheduler
 import uk.gov.hmrc.workitem.{ToDo, WorkItem}
+
+import java.time.{ZoneId, ZonedDateTime}
+import java.util.UUID
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
 
@@ -153,7 +152,7 @@ class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
         ParsedNotification(
           unparsedNotificationId = UUID.randomUUID(),
           actionId = "id1",
-          details = NotificationDetails("mrn", ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("UTC")), ACCEPTED, Seq.empty)
+          details = NotificationDetails("mrn", ZonedDateTime.now(ZoneId.of("UTC")), ACCEPTED, Seq.empty)
         )
       )
       when(notificationRepository.findNotificationsByActionIds(any[Seq[String]])).thenReturn(Future.successful(notifications))

--- a/test/util/testdata/SubmissionTestData.scala
+++ b/test/util/testdata/SubmissionTestData.scala
@@ -16,17 +16,17 @@
 
 package testdata
 
-import java.time.temporal.ChronoUnit.HOURS
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
-import java.util.UUID
-
 import testdata.ExportsTestData._
 import uk.gov.hmrc.exports.models.declaration.submissions.{Action, CancellationRequest, Submission, SubmissionRequest}
 
+import java.time.{ZoneId, ZonedDateTime}
+import java.time.temporal.ChronoUnit.HOURS
+import java.util.UUID
+
 object SubmissionTestData {
 
-  private val instant1971: ZonedDateTime = ZonedDateTime.of(LocalDateTime.of(1971, 1, 1, 1, 1), ZoneId.of("UTC"))
-  private val instant1972 = ZonedDateTime.of(LocalDateTime.of(1972, 1, 1, 1, 1), ZoneId.of("UTC"))
+  private val instant1971: ZonedDateTime = ZonedDateTime.of(1971, 1, 1, 1, 1, 0, 0, ZoneId.of("UTC"))
+  private val instant1972 = ZonedDateTime.of(1972, 1, 1, 1, 1, 0, 0, ZoneId.of("UTC"))
 
   lazy val action = Action(requestType = SubmissionRequest, id = actionId)
   lazy val action_2 =

--- a/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
+++ b/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
@@ -16,14 +16,14 @@
 
 package testdata.notifications
 
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatter.ofPattern
-import java.time.{LocalDateTime, ZonedDateTime, ZoneId, ZoneOffset}
 import uk.gov.hmrc.exports.models.{Pointer, PointerSection}
 import uk.gov.hmrc.exports.models.PointerSectionType.{FIELD, SEQUENCE}
 import uk.gov.hmrc.exports.models.declaration.notifications.{NotificationDetails, NotificationError}
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
 
+import java.time.{ZoneId, ZonedDateTime}
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter.ofPattern
 import scala.xml.Elem
 
 final case class ExampleXmlAndNotificationDetailsPair(asXml: Elem = <empty/>, asDomainModel: Seq[NotificationDetails] = Seq.empty)
@@ -33,11 +33,9 @@ object ExampleXmlAndNotificationDetailsPair {
 
   val formatter304 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
 
-  def exampleReceivedNotification(
-    mrn: String,
-    dateTime: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UCT"))
-  ): ExampleXmlAndNotificationDetailsPair = ExampleXmlAndNotificationDetailsPair(
-    asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
+  def exampleReceivedNotification(mrn: String, dateTime: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UCT"))): ExampleXmlAndNotificationDetailsPair =
+    ExampleXmlAndNotificationDetailsPair(
+      asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
       <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
       <WCOTypeName>RES</WCOTypeName>
       <ResponsibleCountryCode/>
@@ -55,20 +53,20 @@ object ExampleXmlAndNotificationDetailsPair {
         </Declaration>
       </Response>
     </MetaData>,
-    asDomainModel = Seq(
-      NotificationDetails(
-        mrn = mrn,
-        dateTimeIssued = ZonedDateTime.ofInstant(dateTime.toInstant, ZoneId.of("UCT")).withNano(0),
-        status = SubmissionStatus.RECEIVED,
-        errors = Seq.empty
+      asDomainModel = Seq(
+        NotificationDetails(
+          mrn = mrn,
+          dateTimeIssued = dateTime.withZoneSameInstant(ZoneId.of("UCT")).withNano(0),
+          status = SubmissionStatus.RECEIVED,
+          errors = Seq.empty
+        )
       )
     )
-  )
 
   //noinspection ScalaStyle
   def exampleRejectNotification(
     mrn: String,
-    dateTime: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(formatter304),
+    dateTime: String = ZonedDateTime.now(ZoneId.of("UCT")).format(formatter304),
     with67ASequenceNo: Boolean = false
   ): ExampleXmlAndNotificationDetailsPair = ExampleXmlAndNotificationDetailsPair(
     asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
@@ -116,7 +114,7 @@ object ExampleXmlAndNotificationDetailsPair {
     asDomainModel = Seq(
       NotificationDetails(
         mrn = mrn,
-        dateTimeIssued = ZonedDateTime.of(LocalDateTime.parse(dateTime, formatter304), ZoneId.of("UTC")),
+        dateTimeIssued = ZonedDateTime.parse(dateTime, formatter304),
         status = SubmissionStatus.REJECTED,
         errors = Seq(
           NotificationError(
@@ -141,8 +139,8 @@ object ExampleXmlAndNotificationDetailsPair {
 
   def exampleNotificationWithMultipleResponses(
     mrn: String,
-    dateTime_received: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(formatter304),
-    dateTime_accepted: String = LocalDateTime.now().plusHours(1).atZone(ZoneId.of("UCT")).format(formatter304)
+    dateTime_received: String = ZonedDateTime.now(ZoneId.of("UCT")).format(formatter304),
+    dateTime_accepted: String = ZonedDateTime.now(ZoneId.of("UCT")).plusHours(1).format(formatter304)
   ): ExampleXmlAndNotificationDetailsPair = ExampleXmlAndNotificationDetailsPair(
     asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
       <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
@@ -175,13 +173,13 @@ object ExampleXmlAndNotificationDetailsPair {
     asDomainModel = Seq(
       NotificationDetails(
         mrn = mrn,
-        dateTimeIssued = ZonedDateTime.of(LocalDateTime.parse(dateTime_received, formatter304), ZoneId.of("UTC")),
+        dateTimeIssued = ZonedDateTime.parse(dateTime_received, formatter304),
         status = SubmissionStatus.RECEIVED,
         errors = Seq.empty
       ),
       NotificationDetails(
         mrn = mrn,
-        dateTimeIssued = ZonedDateTime.of(LocalDateTime.parse(dateTime_accepted, formatter304), ZoneId.of("UTC")),
+        dateTimeIssued = ZonedDateTime.parse(dateTime_accepted, formatter304),
         status = SubmissionStatus.ACCEPTED,
         errors = Seq.empty
       )
@@ -200,8 +198,8 @@ object ExampleXmlAndNotificationDetailsPair {
 
   def exampleUnparsableNotification(
     mrn: String,
-    dateTime_received: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(formatter304),
-    dateTime_accepted: String = LocalDateTime.now().plusHours(1).atZone(ZoneId.of("UCT")).format(formatter304)
+    dateTime_received: String = ZonedDateTime.now(ZoneId.of("UCT")).format(formatter304),
+    dateTime_accepted: String = ZonedDateTime.now(ZoneId.of("UCT")).plusHours(1).format(formatter304)
   ): ExampleXmlAndNotificationDetailsPair =
     ExampleXmlAndNotificationDetailsPair(asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
       <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
@@ -234,7 +232,7 @@ object ExampleXmlAndNotificationDetailsPair {
 
   def exampleNotificationInIncorrectFormatXML(
     mrn: String,
-    dateTime: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(ofPattern("yyyyMMddHHmmssX"))
+    dateTime: String = ZonedDateTime.now(ZoneId.of("UCT")).format(ofPattern("yyyyMMddHHmmssX"))
   ): ExampleXmlAndNotificationDetailsPair =
     ExampleXmlAndNotificationDetailsPair(asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
       <WCODataModelVersionCode>3.6</WCODataModelVersionCode>

--- a/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
+++ b/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
@@ -18,8 +18,7 @@ package testdata.notifications
 
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatter.ofPattern
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
-
+import java.time.{LocalDateTime, ZonedDateTime, ZoneId, ZoneOffset}
 import uk.gov.hmrc.exports.models.{Pointer, PointerSection}
 import uk.gov.hmrc.exports.models.PointerSectionType.{FIELD, SEQUENCE}
 import uk.gov.hmrc.exports.models.declaration.notifications.{NotificationDetails, NotificationError}
@@ -32,11 +31,11 @@ final case class ExampleXmlAndNotificationDetailsPair(asXml: Elem = <empty/>, as
 
 object ExampleXmlAndNotificationDetailsPair {
 
-  private val formatter304 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
+  val formatter304 = DateTimeFormatter.ofPattern("yyyyMMddHHmmssX")
 
   def exampleReceivedNotification(
     mrn: String,
-    dateTime: String = LocalDateTime.now().atZone(ZoneId.of("UCT")).format(formatter304)
+    dateTime: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UCT"))
   ): ExampleXmlAndNotificationDetailsPair = ExampleXmlAndNotificationDetailsPair(
     asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
       <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
@@ -49,7 +48,7 @@ object ExampleXmlAndNotificationDetailsPair {
         <FunctionCode>02</FunctionCode>
         <FunctionalReferenceID>1234555</FunctionalReferenceID>
         <IssueDateTime>
-          <DateTimeString formatCode="304">{dateTime}</DateTimeString>
+          <DateTimeString formatCode="304">{dateTime.format(formatter304)}</DateTimeString>
         </IssueDateTime>
         <Declaration>
           <ID>{mrn}</ID>
@@ -59,7 +58,7 @@ object ExampleXmlAndNotificationDetailsPair {
     asDomainModel = Seq(
       NotificationDetails(
         mrn = mrn,
-        dateTimeIssued = ZonedDateTime.of(LocalDateTime.parse(dateTime, formatter304), ZoneId.of("UTC")),
+        dateTimeIssued = ZonedDateTime.ofInstant(dateTime.toInstant, ZoneId.of("UCT")).withNano(0),
         status = SubmissionStatus.RECEIVED,
         errors = Seq.empty
       )

--- a/test/util/testdata/notifications/NotificationTestData.scala
+++ b/test/util/testdata/notifications/NotificationTestData.scala
@@ -21,12 +21,12 @@ import play.api.mvc.Codec
 import testdata.ExportsTestData.{actionId, actionId_2, actionId_4, mrn}
 import testdata.TestDataHelper
 import uk.gov.hmrc.exports.controllers.util.CustomsHeaderNames
+import uk.gov.hmrc.exports.models.{Pointer, PointerSection, PointerSectionType}
 import uk.gov.hmrc.exports.models.declaration.notifications.{NotificationDetails, NotificationError, ParsedNotification, UnparsedNotification}
 import uk.gov.hmrc.exports.models.declaration.submissions.SubmissionStatus
-import uk.gov.hmrc.exports.models.{Pointer, PointerSection, PointerSectionType}
 
+import java.time.{ZoneId, ZonedDateTime}
 import java.time.temporal.ChronoUnit.MINUTES
-import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import java.util.UUID
 import scala.util.Random
 import scala.xml.Elem
@@ -82,7 +82,7 @@ object NotificationTestData {
   private lazy val functionCodesRandomised: Iterator[String] = Random.shuffle(functionCodes).toIterator
   private def randomResponseFunctionCode: String = functionCodesRandomised.next()
 
-  val dateTimeIssued: ZonedDateTime = ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("UTC"))
+  val dateTimeIssued: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC"))
   val dateTimeIssued_2: ZonedDateTime = dateTimeIssued.plus(3, MINUTES)
   val dateTimeIssued_3: ZonedDateTime = dateTimeIssued_2.plus(3, MINUTES)
   val functionCode: String = randomResponseFunctionCode


### PR DESCRIPTION
Fix bug when parsing dateTime values in the notification XML payload.
We were converting offset datTime values such as '20220401102910+01' into
UTC values of '2022-04-01T10:29:10Z[UTC]' (not adjusting for the offset!).

This meant that when we displayed these values to the user and adjusted for
BST we were adding +1 hour to the actual dateTime value.