### PR TITLE
BAU_Fix test-only Country names not matching

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/testonly/GenerateDraftDecController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/testonly/GenerateDraftDecController.scala
@@ -89,11 +89,17 @@ object GenerateDraftDecController extends ExportsDeclarationBuilder {
       withDepartureTransport(TransportLeavingTheBorder(Some(Maritime)), "10", "WhTGZVW"),
       withContainerData(Container("container", Seq(Seal("seal1")))),
       withPreviousDocuments(PreviousDocument("271", "zPoj 7Szx1K", None)),
-      withExporterDetails(None, Some(Address("Bags Export", "1 Bags Avenue", "New York", "NA", "United States of America"))),
+      withExporterDetails(
+        None,
+        Some(Address("Bags Export", "1 Bags Avenue", "New York", "NA", "United States of America (the), Including Puerto Rico"))
+      ),
       withDeclarantDetails(Some(request.body.eori)),
       withDeclarantIsExporter("No"),
-      withConsigneeDetails(None, Some(Address("Bags Export", "1 Bags Avenue", "New York", "NA", "United States of America"))),
-      withCarrierDetails(None, Some(Address("XYZ Carrier", "School Road", "London", "WS1 2AB", "United Kingdom"))),
+      withConsigneeDetails(
+        None,
+        Some(Address("Bags Export", "1 Bags Avenue", "New York", "NA", "United States of America (the), Including Puerto Rico"))
+      ),
+      withCarrierDetails(None, Some(Address("XYZ Carrier", "School Road", "London", "WS1 2AB", "United Kingdom, Great Britain, Northern Ireland"))),
       withRepresentativeDetails(Some(EntityDetails(Some("GB717572504502809"), None)), Some("3"), Some("No")),
       withDeclarationAdditionalActors(DeclarationAdditionalActor(Some("AD166297284288300"), Some("WH"))),
       withDeclarationHolders(DeclarationHolder(Some("EXEE"), Some("AD166297284288100"), Some(EoriSource.UserEori))),


### PR DESCRIPTION
Country names used to populate new draft declarations created via the test-only endpoint were using non-standard country names. As a result when the XML was generated for that declaration the country element was missing (as no match could be found).