### PR TITLE
CEDS-4218 Upgrade hmrc mongo to remove jsoup vulnerability

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object AppDependencies {
 
   val bootstrapPlayVersion = "7.1.0"
-  val hmrcMongoVersion = "0.68.0"
+  val hmrcMongoVersion = "0.73.0"
   val testScope = "test,it"
 
   val compile = Seq(


### PR DESCRIPTION
The other vulnerability listed for this service addressed here: https://confluence.tools.tax.service.gov.uk/display/CD/Vulnerability+XStream+CVE-2021-21345