### PR TITLE
CEDS-4736_Amendment_Notifications_are_treated_like_external_amendments

### DIFF
--- a/app/uk/gov/hmrc/exports/controllers/testonly/GenerateSubmittedDecController.scala
+++ b/app/uk/gov/hmrc/exports/controllers/testonly/GenerateSubmittedDecController.scala
@@ -106,7 +106,7 @@ object GenerateSubmittedDecController extends ExportsDeclarationBuilder {
     ParsedNotification(
       unparsedNotificationId = UUID.randomUUID(),
       actionId = actionId,
-      details = NotificationDetails(declaration.consignmentReferences.flatMap(_.mrn).getOrElse(""), TimeUtils.now(), status, Seq.empty)
+      details = NotificationDetails(declaration.consignmentReferences.flatMap(_.mrn).getOrElse(""), TimeUtils.now(), status, version = 1, Seq.empty)
     )
 
   // scalastyle:off

--- a/app/uk/gov/hmrc/exports/migrations/MigrationRoutine.scala
+++ b/app/uk/gov/hmrc/exports/migrations/MigrationRoutine.scala
@@ -22,7 +22,7 @@ import play.api.Logging
 import uk.gov.hmrc.exports.config.AppConfig
 import uk.gov.hmrc.exports.migrations.changelogs.cache._
 import uk.gov.hmrc.exports.migrations.changelogs.emaildetails.RenameSendEmailDetailsToItem
-import uk.gov.hmrc.exports.migrations.changelogs.notification.{MakeParsedDetailsOptional, SplitTheNotificationsCollection}
+import uk.gov.hmrc.exports.migrations.changelogs.notification.{AddVersionField, MakeParsedDetailsOptional, SplitTheNotificationsCollection}
 import uk.gov.hmrc.exports.migrations.changelogs.submission._
 
 import javax.inject.Inject
@@ -57,6 +57,7 @@ class MigrationRoutine @Inject() (appConfig: AppConfig) extends Logging {
     .register(new AddSequenceIdsToPackageInformation())
     .register(new RemoveBlockAmendmentsField())
     .register(new SetEnhancedStatusAsNonOptional())
+    .register(new AddVersionField())
 
   ExportsMigrationTool(db, migrationsRegistry, lockManagerConfig).execute()
 

--- a/app/uk/gov/hmrc/exports/migrations/changelogs/notification/AddVersionField.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/notification/AddVersionField.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs.notification
+
+import com.mongodb.client.MongoDatabase
+import org.bson.Document
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model.{Filters, UpdateOneModel}
+import org.mongodb.scala.model.Filters.{and, eq => feq}
+import org.mongodb.scala.model.Updates.set
+import play.api.Logging
+import uk.gov.hmrc.exports.migrations.changelogs.{MigrationDefinition, MigrationInformation}
+
+import scala.jdk.CollectionConverters._
+
+class AddVersionField extends MigrationDefinition with Logging {
+
+  private val INDEX_ID = "_id"
+  private val VERSION = "version"
+  private val DETAILS = "details"
+
+  private val collectionName = "notifications"
+
+  override val migrationInformation: MigrationInformation =
+    MigrationInformation(
+      id = "CEDS-4736 Add versionID field with default value of 1 to NotificationDeails entity",
+      order = 23,
+      author = "Tim Wilkins"
+    )
+
+  override def migrationFunction(db: MongoDatabase): Unit = {
+    logger.info(s"Applying '${migrationInformation.id}' db migration...  ")
+
+    val query = Filters.exists(s"$DETAILS.$VERSION", false)
+    val queryBatchSize = 10
+    val updateBatchSize = 10
+
+    val collection = db.getCollection(collectionName)
+
+    getDocumentsToUpdate(db, query, queryBatchSize).map { document =>
+      val documentId = document.get(INDEX_ID)
+      val filter = and(feq(INDEX_ID, documentId))
+      val update = set(s"$DETAILS.$VERSION", "1")
+      logger.info(s"[filter: $filter] [update: $update]")
+
+      new UpdateOneModel[Document](filter, update)
+    }.grouped(updateBatchSize).zipWithIndex.foreach { case (requests, idx) =>
+      logger.info(s"Updating batch no. $idx...")
+
+      collection.bulkWrite(requests.asJava)
+      logger.info(s"Updated batch no. $idx")
+    }
+
+    logger.info(s"Applying '${migrationInformation.id}' db migration... Done.")
+  }
+
+  private def getDocumentsToUpdate(db: MongoDatabase, filter: Bson, queryBatchSize: Int): Iterator[Document] =
+    db.getCollection(collectionName)
+      .find(filter)
+      .batchSize(queryBatchSize)
+      .iterator
+      .asScala
+}

--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/NotificationDetails.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/NotificationDetails.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.exports.util.TimeUtils.defaultTimeZone
 
 import java.time.{LocalDateTime, ZonedDateTime}
 
-case class NotificationDetails(mrn: String, dateTimeIssued: ZonedDateTime, status: SubmissionStatus, errors: Seq[NotificationError])
+case class NotificationDetails(mrn: String, dateTimeIssued: ZonedDateTime, status: SubmissionStatus, version: Int, errors: Seq[NotificationError])
 
 object NotificationDetails {
   implicit val readLocalDateTimeFromString: Reads[ZonedDateTime] = implicitly[Reads[LocalDateTime]]
@@ -34,6 +34,7 @@ object NotificationDetails {
     ((__ \ "mrn").read[String] and
       ((__ \ "dateTimeIssued").read[ZonedDateTime] or (__ \ "dateTimeIssued").read[ZonedDateTime](readLocalDateTimeFromString)) and
       (__ \ "status").read[SubmissionStatus] and
+      (__ \ "version").read[Int] and
       (__ \ "errors").read[Seq[NotificationError]])(NotificationDetails.apply _)
 
   implicit val format: Format[NotificationDetails] = Format(reads, writes)

--- a/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
+++ b/app/uk/gov/hmrc/exports/repositories/SubmissionRepository.scala
@@ -55,16 +55,6 @@ class SubmissionRepository @Inject() (val mongoComponent: MongoComponent)(implic
     findOneAndUpdate(filter, update)
   }
 
-  def addExternalAmendmentAction(uuid: String, action: Action): Future[Option[Submission]] = {
-    val filter = Json.obj("uuid" -> uuid)
-    val update = Json.obj(
-      "$addToSet" -> Json.obj("actions" -> Json.toJson(action)),
-      "$inc" -> Json.obj("latestVersionNo" -> 1),
-      "$unset" -> Json.obj("latestDecId" -> "")
-    )
-    findOneAndUpdate(filter, update)
-  }
-
   def updateAction(submissionId: String, actionId: String, decId: String): Future[Option[Submission]] =
     collection
       .findOneAndUpdate(

--- a/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
@@ -35,6 +35,7 @@ class NotificationParser extends Logging {
 
     responsesXml.map { singleResponseXml =>
       val mrn = (singleResponseXml \ "Declaration" \ "ID").text
+      val version = (singleResponseXml \ "Declaration" \ "VersionID").text.toInt
       val dateTimeIssued = ZonedDateTime.parse((singleResponseXml \ "IssueDateTime" \ "DateTimeString").text, formatter304)
       val functionCode = (singleResponseXml \ "FunctionCode").text
 
@@ -46,6 +47,7 @@ class NotificationParser extends Logging {
         mrn = mrn,
         dateTimeIssued = dateTimeIssued.withZoneSameInstant(defaultTimeZone),
         status = SubmissionStatus.retrieve(functionCode, nameCode),
+        version,
         errors = errors
       )
     }

--- a/test/it/uk/gov/hmrc/exports/migrations/changelogs/notification/AddVersionFieldISpec.scala
+++ b/test/it/uk/gov/hmrc/exports/migrations/changelogs/notification/AddVersionFieldISpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.migrations.changelogs.notification
+
+import uk.gov.hmrc.exports.base.IntegrationTestMigrationToolSpec
+import uk.gov.hmrc.exports.migrations.changelogs.notification.AddVersionFieldISpec._
+
+class AddVersionFieldISpec extends IntegrationTestMigrationToolSpec {
+
+  override val collectionUnderTest = "notifications"
+  override val changeLog = new AddVersionField()
+
+  "AddVersionField" should {
+
+    "add 'version' field with default value of '1' for all notifications missing this field" in {
+      runTest(notificationBeforeMigration, notificationAfterMigration)
+    }
+
+    "not change notifications already containing the 'version' field" in {
+      runTest(notificationNotRequiringMigration, notificationNotRequiringMigration)
+    }
+  }
+}
+
+object AddVersionFieldISpec {
+
+  val notificationBeforeMigration: String =
+    """{
+      |    "_id" : "5fc0d62750c11c0797a2456f",
+      |    "actionId" : "b1c09f1b-7c94-4e90-b754-7c5c71c44e11",
+      |    "payload" : "RhzDC5lT6ZrWSCHrtoy6wUkL2VdjXLNm8N6PdbyFLpE1jnBqigGsgHuS4CrPO5J8vLtkUZZe0nkNseSa9x5Epb3yuOgZYB6uV272UwCx2utsdqb2U5XEblaYNaWUdifZl9IJVNo39yy0A3XpWdB3avkKCxSn1qNW5Ar3CE4uSi1D5C4oEFUDoQqo484Y9Kt8BtQsabBzC8IaR2vUMhOEJHk5j7HJDIeQ0JGujOWY9QBm13LfAYfBoIrM3GYBJcgR45L9NfVIwVAlkkXbtsaqdVwpRyuayuy8VYyyhyFk4Uc3",
+      |    "details" : {
+      |        "mrn" : "MRN87878797",
+      |        "dateTimeIssued" : "2020-11-27T10:37:10.918Z[UTC]",
+      |        "status" : "UNKNOWN",
+      |        "errors" : [
+      |            {
+      |                "validationCode" : "CDS12056",
+      |                "pointer" : "42A"
+      |            }
+      |        ]
+      |    }
+      |}""".stripMargin
+
+  val notificationAfterMigration: String =
+    """{
+      |    "_id" : "5fc0d62750c11c0797a2456f",
+      |    "actionId" : "b1c09f1b-7c94-4e90-b754-7c5c71c44e11",
+      |    "payload" : "RhzDC5lT6ZrWSCHrtoy6wUkL2VdjXLNm8N6PdbyFLpE1jnBqigGsgHuS4CrPO5J8vLtkUZZe0nkNseSa9x5Epb3yuOgZYB6uV272UwCx2utsdqb2U5XEblaYNaWUdifZl9IJVNo39yy0A3XpWdB3avkKCxSn1qNW5Ar3CE4uSi1D5C4oEFUDoQqo484Y9Kt8BtQsabBzC8IaR2vUMhOEJHk5j7HJDIeQ0JGujOWY9QBm13LfAYfBoIrM3GYBJcgR45L9NfVIwVAlkkXbtsaqdVwpRyuayuy8VYyyhyFk4Uc3",
+      |    "details" : {
+      |        "mrn" : "MRN87878797",
+      |        "dateTimeIssued" : "2020-11-27T10:37:10.918Z[UTC]",
+      |        "status" : "UNKNOWN",
+      |        "version" : "1",
+      |        "errors" : [
+      |            {
+      |                "validationCode" : "CDS12056",
+      |                "pointer" : "42A"
+      |            }
+      |        ]
+      |    }
+      |}""".stripMargin
+
+  val notificationNotRequiringMigration: String =
+    """{
+      |    "_id" : "5fc0d62750c11c0797a2456f",
+      |    "actionId" : "b1c09f1b-7c94-4e90-b754-7c5c71c44e11",
+      |    "payload" : "RhzDC5lT6ZrWSCHrtoy6wUkL2VdjXLNm8N6PdbyFLpE1jnBqigGsgHuS4CrPO5J8vLtkUZZe0nkNseSa9x5Epb3yuOgZYB6uV272UwCx2utsdqb2U5XEblaYNaWUdifZl9IJVNo39yy0A3XpWdB3avkKCxSn1qNW5Ar3CE4uSi1D5C4oEFUDoQqo484Y9Kt8BtQsabBzC8IaR2vUMhOEJHk5j7HJDIeQ0JGujOWY9QBm13LfAYfBoIrM3GYBJcgR45L9NfVIwVAlkkXbtsaqdVwpRyuayuy8VYyyhyFk4Uc3",
+      |    "details" : {
+      |        "mrn" : "MRN87878797",
+      |        "dateTimeIssued" : "2020-11-27T10:37:10.918Z[UTC]",
+      |        "status" : "UNKNOWN",
+      |        "version" : "2",
+      |        "errors" : [
+      |            {
+      |                "validationCode" : "CDS12056",
+      |                "pointer" : "42A"
+      |            }
+      |        ]
+      |    }
+      |}""".stripMargin
+}

--- a/test/it/uk/gov/hmrc/exports/migrations/changelogs/submission/AddNotificationSummariesToSubmissionsISpec.scala
+++ b/test/it/uk/gov/hmrc/exports/migrations/changelogs/submission/AddNotificationSummariesToSubmissionsISpec.scala
@@ -288,6 +288,7 @@ object AddNotificationSummariesToSubmissionsISpec {
       |      "mrn" : "18GBJP3OS8Y5KKS9I9",
       |      "dateTimeIssued" : "2022-06-13T09:11:09Z[UTC]",
       |      "status" : "ACCEPTED",
+      |      "version" : 1,
       |      "errors" : []
       |  }
       |}""".stripMargin,
@@ -298,6 +299,7 @@ object AddNotificationSummariesToSubmissionsISpec {
       |      "mrn" : "18GBJP3OS8Y5KKS9I9",
       |      "dateTimeIssued" : "2022-06-13T09:01:09Z[UTC]",
       |      "status" : "GOODS_HAVE_EXITED_THE_COMMUNITY",
+      |      "version" : 1,
       |      "errors" : []
       |  }
       |}""".stripMargin,
@@ -308,6 +310,7 @@ object AddNotificationSummariesToSubmissionsISpec {
       |      "mrn" : "18GBJP3OS8Y5KKS9I9",
       |      "dateTimeIssued" : "2022-06-13T09:06:09Z[UTC]",
       |      "status" : "CLEARED",
+      |      "version" : 1,
       |      "errors" : []
       |  }
       |}""".stripMargin
@@ -320,6 +323,7 @@ object AddNotificationSummariesToSubmissionsISpec {
       |      "mrn" : "18GBJP3OS8Y5KKS9I9",
       |      "dateTimeIssued" : "2022-06-20T14:52:13Z[UTC]",
       |      "status" : "CANCELLED",
+      |      "version" : 1,
       |      "errors" : []
       |  }
       |}""".stripMargin)

--- a/test/it/uk/gov/hmrc/exports/scheduler/jobs/PurgeAncientSubmissionsJobISpec.scala
+++ b/test/it/uk/gov/hmrc/exports/scheduler/jobs/PurgeAncientSubmissionsJobISpec.scala
@@ -390,6 +390,7 @@ object PurgeAncientSubmissionsJobISpec {
         "22GB1168DI14797408",
         ZonedDateTime.parse("2022-08-02T13:20:06Z[UTC]"),
         SubmissionStatus.GOODS_HAVE_EXITED_THE_COMMUNITY,
+        version = 1,
         Seq.empty
       )
     )

--- a/test/it/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionISpec.scala
+++ b/test/it/uk/gov/hmrc/exports/services/notifications/receiptactions/ParseAndSaveActionISpec.scala
@@ -205,6 +205,7 @@ object ParseAndSaveActionISpec {
       mrn = mrn,
       dateTimeIssued = ZonedDateTime.parse(cancellationDateTime),
       status = SubmissionStatus.CANCELLED,
+      version = 1,
       errors = List.empty
     )
   )
@@ -215,8 +216,13 @@ object ParseAndSaveActionISpec {
   val submissionNotification = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = submissionActionId,
-    details =
-      NotificationDetails(mrn = mrn, dateTimeIssued = ZonedDateTime.parse(submissionDateTime), status = SubmissionStatus.REJECTED, errors = errors)
+    details = NotificationDetails(
+      mrn = mrn,
+      dateTimeIssued = ZonedDateTime.parse(submissionDateTime),
+      status = SubmissionStatus.REJECTED,
+      version = 1,
+      errors = errors
+    )
   )
 
   val id: String = "9f324b20-71bf-4c70-ae8d-aa53f81a99ff"

--- a/test/unit/uk/gov/hmrc/exports/models/declaration/notifications/ParsedNotificationSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/models/declaration/notifications/ParsedNotificationSpec.scala
@@ -40,7 +40,7 @@ class ParsedNotificationSpec extends UnitSpec {
       _id = id,
       unparsedNotificationId,
       actionId = actionId,
-      details = NotificationDetails(mrn, dateTime, SubmissionStatus.ACCEPTED, Seq.empty)
+      details = NotificationDetails(mrn, dateTime, SubmissionStatus.ACCEPTED, version = 1, Seq.empty)
     )
 
     "have json writes that produce object which could be parsed by the front end service" in {
@@ -68,5 +68,5 @@ object ParsedNotificationSpec {
     s"""{"actionId":"${actionId}","mrn":"${mrn}","dateTimeIssued":"${dateTime}","status":"ACCEPTED","errors":[]}"""
 
   def serialisedWithDbFormat(_id: String, unparsedNotificationId: String, actionId: String, mrn: String, dateTime: String) =
-    s"""{"_id":{"$$oid":"${_id}"},"unparsedNotificationId":"${unparsedNotificationId}","actionId":"${actionId}","details":{"mrn":"${mrn}","dateTimeIssued":"${dateTime}","status":"ACCEPTED","errors":[]}}"""
+    s"""{"_id":{"$$oid":"${_id}"},"unparsedNotificationId":"${unparsedNotificationId}","actionId":"${actionId}","details":{"mrn":"${mrn}","dateTimeIssued":"${dateTime}","status":"ACCEPTED","version":1,"errors":[]}}"""
 }

--- a/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/EmailCancellationValidatorSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/scheduler/jobs/emails/EmailCancellationValidatorSpec.scala
@@ -48,7 +48,7 @@ class EmailCancellationValidatorSpec extends UnitSpec {
   def createNotification(dateTimeIssued: ZonedDateTime, status: SubmissionStatus) = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID(),
     actionId = actionId,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = status, errors = Seq.empty)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = status, version = 1, errors = Seq.empty)
   )
 
   "EmailSendingValidator on isEmailSendingCancelled" should {

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationServiceSpec.scala
@@ -87,7 +87,7 @@ class NotificationServiceSpec extends UnitSpec with IntegrationPatience {
         ParsedNotification(
           unparsedNotificationId = UUID.randomUUID(),
           actionId = "id1",
-          details = NotificationDetails("mrn", now, ACCEPTED, Seq.empty)
+          details = NotificationDetails("mrn", now, ACCEPTED, 1, Seq.empty)
         )
       )
       when(notificationRepository.findNotifications(any[Seq[String]])).thenReturn(Future.successful(notifications))

--- a/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
+++ b/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
@@ -51,6 +51,7 @@ object ExampleXmlAndNotificationDetailsPair {
         </IssueDateTime>
         <Declaration>
           <ID>{mrn}</ID>
+          <VersionID>1</VersionID>
         </Declaration>
       </Response>
     </MetaData>,
@@ -59,6 +60,7 @@ object ExampleXmlAndNotificationDetailsPair {
           mrn = mrn,
           dateTimeIssued = dateTime.withZoneSameInstant(ZoneId.of("UCT")).withNano(0),
           status = SubmissionStatus.RECEIVED,
+          version = 1,
           errors = Seq.empty
         )
       )
@@ -117,6 +119,7 @@ object ExampleXmlAndNotificationDetailsPair {
         mrn = mrn,
         dateTimeIssued = ZonedDateTime.parse(dateTime, formatter304),
         status = SubmissionStatus.REJECTED,
+        1,
         errors = Seq(
           NotificationError(
             validationCode = "CDS10020",
@@ -158,6 +161,7 @@ object ExampleXmlAndNotificationDetailsPair {
         </IssueDateTime>
         <Declaration>
           <ID>{mrn}</ID>
+          <VersionID>1</VersionID>
         </Declaration>
       </Response>
       <Response>
@@ -168,6 +172,7 @@ object ExampleXmlAndNotificationDetailsPair {
         </IssueDateTime>
         <Declaration>
           <ID>{mrn}</ID>
+          <VersionID>1</VersionID>
         </Declaration>
       </Response>
     </MetaData>,
@@ -176,12 +181,14 @@ object ExampleXmlAndNotificationDetailsPair {
         mrn = mrn,
         dateTimeIssued = ZonedDateTime.parse(dateTime_received, formatter304),
         status = SubmissionStatus.RECEIVED,
+        version = 1,
         errors = Seq.empty
       ),
       NotificationDetails(
         mrn = mrn,
         dateTimeIssued = ZonedDateTime.parse(dateTime_accepted, formatter304),
         status = SubmissionStatus.ACCEPTED,
+        version = 1,
         errors = Seq.empty
       )
     )
@@ -221,6 +228,7 @@ object ExampleXmlAndNotificationDetailsPair {
         </IssueDateTime>
         <Declaration>
           <ID>{mrn}</ID>
+          <VersionID>1</VersionID>
         </Declaration>
       </Response>
       <Response>
@@ -231,6 +239,7 @@ object ExampleXmlAndNotificationDetailsPair {
         </wrong>
         <Declaration>
           <ID>{mrn}</ID>
+          <VersionID>1</VersionID>
         </Declaration>
       </Response>
     </MetaData>,

--- a/test/util/testdata/notifications/NotificationTestData.scala
+++ b/test/util/testdata/notifications/NotificationTestData.scala
@@ -100,24 +100,27 @@ object NotificationTestData {
   val notification = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = actionId,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = UNKNOWN, errors = errors)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = UNKNOWN, version = 1, errors = errors)
   )
   val notification_2 = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = actionId,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_2, status = UNKNOWN, errors = errors)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_2, status = UNKNOWN, version = 1, errors = errors)
   )
   val notification_3 = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = actionId_2,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_3, status = UNKNOWN, errors = Seq.empty)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_3, status = UNKNOWN, version = 1, errors = Seq.empty)
   )
 
   val notificationForExternalAmendment = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = actionId,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_3, status = AMENDED, errors = Seq.empty)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_3, status = AMENDED, version = 2, errors = Seq.empty)
   )
+
+  val notificationForExternalAmendmentV1 =
+    notificationForExternalAmendment.copy(details = notificationForExternalAmendment.details.copy(version = 1))
 
   val notificationUnparsed = UnparsedNotification(actionId = actionId_4, payload = payload)
 }


### PR DESCRIPTION
When receiving amendment notifications, ensure that only notifications with a declaration VersionID value greater than the corresponding declaration's cached latestVersionNo are processed. Those with VersionID less than or equal to the corresponding declaration's cached latestVersionNo are ignored.