### PR TITLE
BAU Investigating notifications failed to be parsed causing excessive…

### DIFF
--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsRunner.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsRunner.scala
@@ -56,8 +56,8 @@ class NotificationReceiptActionsRunner @Inject() (
       .flatMap { _ =>
         unparsedNotificationWorkItemRepository.complete(unparsedNotificationWorkItem.id, Succeeded)
       }
-      .recoverWith { case _ =>
+      .recoverWith { case e =>
+        logger.warn(s"[Notification parsing error] parsing id:${unparsedNotificationWorkItem.item.id}' Failed!", e)
         unparsedNotificationWorkItemRepository.markAs(unparsedNotificationWorkItem.id, Failed)
       }
-
 }


### PR DESCRIPTION
… mongo traffic

Our processing of notifications sent in response to an amendment request was not setup to handle the RECEIVED (02) notification and so was throwing an exception that was stopping the UnparsedNotification from being marked as 'Successful'. This resulted in the UnparsedNotification continuously being reattempted hundereds of thousands of times, and the growing number of these notifications started to affect the mongo cluster in QA!