### PR TITLE
CEDS-5025 Parse and store Description element from error notifications

### DIFF
--- a/app/uk/gov/hmrc/exports/models/declaration/notifications/NotificationError.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/notifications/NotificationError.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.exports.models.declaration.notifications
 import play.api.libs.json.Json
 import uk.gov.hmrc.exports.models.Pointer
 
-case class NotificationError(validationCode: String, pointer: Option[Pointer])
+case class NotificationError(validationCode: String, pointer: Option[Pointer], description: Option[String] = None)
 
 object NotificationError {
   implicit val format = Json.format[NotificationError]

--- a/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/NotificationParser.scala
@@ -57,10 +57,11 @@ class NotificationParser extends Logging {
     if ((singleResponseXml \ "Error").nonEmpty) {
       val errorsXml = singleResponseXml \ "Error"
       errorsXml.map { singleErrorXml =>
+        val description = if ((singleErrorXml \ "Description").nonEmpty) Some((singleErrorXml \ "Description").text) else None
         val validationCode = (singleErrorXml \ "ValidationCode").text
         val pointer =
           if ((singleErrorXml \ "Pointer").nonEmpty) buildErrorPointer(singleErrorXml) else None
-        NotificationError(validationCode, pointer)
+        NotificationError(validationCode, pointer, description)
       }
     } else Seq.empty
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.13.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/notifications/NotificationParserSpec.scala
@@ -87,6 +87,16 @@ class NotificationParserSpec extends UnitSpec {
           compareNotificationSequences(result, testNotification.asDomainModel)
         }
       }
+
+      "contains child description element in parent error element" should {
+        "return single NotificationDetails with errors populated with a smartErrorDescription" in {
+          val testNotification = exampleRejectNotification(mrn, withErrorDescription = true)
+
+          val result = notificationParser.parse(testNotification.asXml)
+
+          compareNotificationSequences(result, testNotification.asDomainModel)
+        }
+      }
     }
 
     "provided with notification containing multiple Response elements" should {

--- a/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
+++ b/test/util/testdata/notifications/ExampleXmlAndNotificationDetailsPair.scala
@@ -101,76 +101,84 @@ object ExampleXmlAndNotificationDetailsPair {
   def exampleRejectNotification(
     mrn: String,
     dateTime: String = TimeUtils.now().format(formatter304),
-    with67ASequenceNo: Boolean = false
-  ): ExampleXmlAndNotificationDetailsPair = ExampleXmlAndNotificationDetailsPair(
-    asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
-      <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
-      <WCOTypeName>RES</WCOTypeName>
-      <ResponsibleCountryCode/>
-      <ResponsibleAgencyName/>
-      <AgencyAssignedCustomizationCode/>
-      <AgencyAssignedCustomizationVersionCode/>
-      <Response>
-        <FunctionCode>03</FunctionCode>
-        <FunctionalReferenceID>6be6c6f61f0346748016b823eeda669d</FunctionalReferenceID>
-        <IssueDateTime>
-          <DateTimeString formatCode="304">{dateTime}</DateTimeString>
-        </IssueDateTime>
-        <Error>
-          <ValidationCode>CDS10020</ValidationCode>
-          <Pointer>
-            <DocumentSectionCode>42A</DocumentSectionCode>
-          </Pointer>
-          <Pointer>
-            {if (with67ASequenceNo) <SequenceNumeric>1</SequenceNumeric>}
-            <DocumentSectionCode>67A</DocumentSectionCode>
-          </Pointer>
-          <Pointer>
-            <SequenceNumeric>1</SequenceNumeric>
-            <DocumentSectionCode>68A</DocumentSectionCode>
-          </Pointer>
-          <Pointer>
-            <SequenceNumeric>2</SequenceNumeric>
-            <DocumentSectionCode>02A</DocumentSectionCode>
-            <TagID>360</TagID>
-          </Pointer>
-        </Error>
-        <Declaration>
-          <FunctionalReferenceID>NotificationTest</FunctionalReferenceID>
-          <ID>{mrn}</ID>
-          <RejectionDateTime>
-            <DateTimeString formatCode="304">20190328092916Z</DateTimeString>
-          </RejectionDateTime>
-          <VersionID>1</VersionID>
-        </Declaration>
-      </Response>
-    </MetaData>,
-    asDomainModel = Seq(
-      NotificationDetails(
-        mrn = mrn,
-        dateTimeIssued = ZonedDateTime.parse(dateTime, formatter304),
-        status = SubmissionStatus.REJECTED,
-        Some(1),
-        errors = Seq(
-          NotificationError(
-            validationCode = "CDS10020",
-            pointer = Some(
-              Pointer(
-                Seq(
-                  PointerSection("declaration", FIELD),
-                  PointerSection("items", FIELD),
-                  PointerSection("1", SEQUENCE),
-                  PointerSection("additionalDocument", FIELD),
-                  PointerSection("2", SEQUENCE),
-                  PointerSection("documentStatus", FIELD)
+    with67ASequenceNo: Boolean = false,
+    withErrorDescription: Boolean = false
+  ): ExampleXmlAndNotificationDetailsPair = {
+
+    val errorDescription = if (withErrorDescription) Some("Extra description") else None
+
+    ExampleXmlAndNotificationDetailsPair(
+      asXml = <MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2">
+        <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
+        <WCOTypeName>RES</WCOTypeName>
+        <ResponsibleCountryCode/>
+        <ResponsibleAgencyName/>
+        <AgencyAssignedCustomizationCode/>
+        <AgencyAssignedCustomizationVersionCode/>
+        <Response>
+          <FunctionCode>03</FunctionCode>
+          <FunctionalReferenceID>6be6c6f61f0346748016b823eeda669d</FunctionalReferenceID>
+          <IssueDateTime>
+            <DateTimeString formatCode="304">{dateTime}</DateTimeString>
+          </IssueDateTime>
+          <Error>
+            {if (withErrorDescription) <Description>{errorDescription.get}</Description>}
+            <ValidationCode>CDS10020</ValidationCode>
+            <Pointer>
+              <DocumentSectionCode>42A</DocumentSectionCode>
+            </Pointer>
+            <Pointer>
+              {if (with67ASequenceNo) <SequenceNumeric>1</SequenceNumeric>}
+              <DocumentSectionCode>67A</DocumentSectionCode>
+            </Pointer>
+            <Pointer>
+              <SequenceNumeric>1</SequenceNumeric>
+              <DocumentSectionCode>68A</DocumentSectionCode>
+            </Pointer>
+            <Pointer>
+              <SequenceNumeric>2</SequenceNumeric>
+              <DocumentSectionCode>02A</DocumentSectionCode>
+              <TagID>360</TagID>
+            </Pointer>
+          </Error>
+          <Declaration>
+            <FunctionalReferenceID>NotificationTest</FunctionalReferenceID>
+            <ID>{mrn}</ID>
+            <RejectionDateTime>
+              <DateTimeString formatCode="304">20190328092916Z</DateTimeString>
+            </RejectionDateTime>
+            <VersionID>1</VersionID>
+          </Declaration>
+        </Response>
+      </MetaData>,
+      asDomainModel = Seq(
+        NotificationDetails(
+          mrn = mrn,
+          dateTimeIssued = ZonedDateTime.parse(dateTime, formatter304),
+          status = SubmissionStatus.REJECTED,
+          Some(1),
+          errors = Seq(
+            NotificationError(
+              validationCode = "CDS10020",
+              pointer = Some(
+                Pointer(
+                  Seq(
+                    PointerSection("declaration", FIELD),
+                    PointerSection("items", FIELD),
+                    PointerSection("1", SEQUENCE),
+                    PointerSection("additionalDocument", FIELD),
+                    PointerSection("2", SEQUENCE),
+                    PointerSection("documentStatus", FIELD)
+                  )
                 )
-              )
+              ),
+              errorDescription
             )
           )
         )
       )
     )
-  )
+  }
 
   def exampleNotificationWithMultipleResponses(
     mrn: String,
@@ -328,5 +336,4 @@ object ExampleXmlAndNotificationDetailsPair {
     </MetaData>,
       asDomainModel = Seq.empty
     )
-
 }


### PR DESCRIPTION
The <error> elements sometimes contain child <description> elements. This change will mean that we capture this info in our mongo store