### PR TITLE
CEDS-5206 Add new event on Notification Processing

### DIFF
--- a/app/uk/gov/hmrc/exports/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/exports/config/AppConfig.scala
@@ -22,10 +22,11 @@ import uk.gov.hmrc.exports.config.AppConfig.JobConfig
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import java.time.{Clock, LocalTime}
+import javax.inject.Named
 import scala.concurrent.duration.FiniteDuration
 
 @Singleton
-class AppConfig @Inject() (val configuration: Configuration, servicesConfig: ServicesConfig) {
+class AppConfig @Inject() (val configuration: Configuration, servicesConfig: ServicesConfig, @Named("appName") val appName: String) {
 
   lazy val clock: Clock = Clock.systemUTC()
 

--- a/app/uk/gov/hmrc/exports/models/declaration/submissions/SubmissionStatus.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/submissions/SubmissionStatus.scala
@@ -52,6 +52,8 @@ object SubmissionStatus extends Enumeration {
     "UnknownStatus" -> UNKNOWN
   )
 
+  val statusMap = codesMap.map(_.swap)
+
   def retrieve(functionCode: String, nameCode: Option[String] = None): SubmissionStatus =
     getStatusOrUnknown(buildSearchKey(functionCode, nameCode))
 

--- a/app/uk/gov/hmrc/exports/services/audit/AuditNotifications.scala
+++ b/app/uk/gov/hmrc/exports/services/audit/AuditNotifications.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.audit
+
+import play.api.libs.json.{JsObject, Json}
+import uk.gov.hmrc.exports.models.declaration.submissions.Submission
+import uk.gov.hmrc.exports.services.audit.AuditTypes.NotificationProcessed
+
+object AuditNotifications {
+  def audit(
+    submission: Submission,
+    declarationId: String,
+    functionCodes: Seq[String],
+    validationCodes: Seq[String],
+    conversationId: String,
+    auditService: AuditService
+  ): Unit = {
+    val auditData: Map[String, String] = Map(
+      EventData.ducr.toString -> submission.ducr,
+      EventData.lrn.toString -> submission.lrn,
+      EventData.eori.toString -> submission.eori,
+      EventData.declarationId.toString -> submission.uuid,
+      EventData.conversationId.toString -> conversationId
+    )
+
+    val optionalKeyValues = Seq((EventData.mrn.toString -> submission.mrn))
+
+    val optionalDataElements = optionalKeyValues.foldLeft(Map.empty[String, String]) { (acc, item) =>
+      item._2
+        .map(v => acc + (item._1 -> v))
+        .getOrElse(acc)
+    }
+
+    def mergeValidationCodes(payload: JsObject): JsObject =
+      if (validationCodes.isEmpty) payload
+      else {
+        val arrayField = Json.toJson(Map(EventData.validationCodes.toString -> validationCodes)).as[JsObject]
+        payload.deepMerge(arrayField)
+      }
+
+    def mergeFunctionCodes(payload: JsObject): JsObject =
+      if (functionCodes.isEmpty) payload
+      else {
+        val arrayField = Json.toJson(Map(EventData.functionCodes.toString -> functionCodes)).as[JsObject]
+        payload.deepMerge(arrayField)
+      }
+
+    val mergeArrayValues = mergeValidationCodes _ andThen mergeFunctionCodes _
+
+    val auditPayload = Json.toJson(auditData ++ optionalDataElements).as[JsObject]
+    val completePayload = mergeArrayValues(auditPayload)
+
+    auditService.auditNotificationProcessed(NotificationProcessed, completePayload)
+  }
+}

--- a/app/uk/gov/hmrc/exports/services/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/exports/services/audit/AuditService.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.exports.services.audit
+
+import com.google.inject.Inject
+import play.api.Logging
+import play.api.libs.json.JsObject
+import uk.gov.hmrc.exports.config.AppConfig
+import uk.gov.hmrc.exports.services.audit.AuditTypes.Audit
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.audit.http.connector.{AuditConnector, AuditResult}
+import uk.gov.hmrc.play.audit.http.connector.AuditResult.{Disabled, Failure, Success}
+import uk.gov.hmrc.play.audit.model.ExtendedDataEvent
+import uk.gov.hmrc.play.audit.AuditExtensions
+
+import scala.concurrent.ExecutionContext
+
+class AuditService @Inject() (connector: AuditConnector, appConfig: AppConfig)(implicit ec: ExecutionContext) extends Logging {
+
+  def auditNotificationProcessed(audit: Audit, auditData: JsObject) = {
+
+    val extendedEvent = ExtendedDataEvent(
+      auditSource = appConfig.appName,
+      auditType = audit.toString,
+      tags = getAuditTags(s"${audit.toString}", path = s"${audit.toString}")(HeaderCarrier()),
+      detail = auditData
+    )
+
+    connector.sendExtendedEvent(extendedEvent).map(handleResponse(_, audit.toString))
+  }
+
+  private def handleResponse(result: AuditResult, auditType: String): AuditResult = result match {
+    case Success =>
+      logger.debug(s"Exports $auditType audit successful")
+      Success
+
+    case Failure(err, _) =>
+      logger.warn(s"Exports $auditType Audit Error, message: $err")
+      Failure(err)
+
+    case Disabled =>
+      logger.warn(s"Auditing Disabled")
+      Disabled
+  }
+
+  private def getAuditTags(transactionName: String, path: String)(implicit hc: HeaderCarrier): Map[String, String] =
+    AuditExtensions
+      .auditHeaderCarrier(hc)
+      .toAuditTags(transactionName = s"export-declaration-${transactionName.toLowerCase}", path = s"customs-declare-exports/$path")
+
+}
+
+object AuditTypes extends Enumeration {
+  type Audit = Value
+  val NotificationProcessed = Value
+}
+
+object EventData extends Enumeration {
+  type Data = Value
+
+  val eori, lrn, mrn, ducr, decType, declarationId, conversationId, functionCodes, validationCodes = Value
+}

--- a/test/it/uk/gov/hmrc/exports/repositories/UpdateSubmissionsTransactionalOpsISpec.scala
+++ b/test/it/uk/gov/hmrc/exports/repositories/UpdateSubmissionsTransactionalOpsISpec.scala
@@ -64,7 +64,7 @@ class UpdateSubmissionsTransactionalOpsISpec extends IntegrationTestSpec {
         "the stored Submission document's related action DOES NOT CONTAIN yet any NotificationSummary" should {
           "return the Submission document with the action including a new NotificationSummary and MRN" in {
             val storedSubmission = submissionRepository.insertOne(pendingSubmissionWithoutMrn).futureValue.toOption.get
-            testUpdateSubmissionAndNotifications(actionId, List(notification), storedSubmission, UNKNOWN, 1)
+            testUpdateSubmissionAndNotifications(actionId, List(notification), storedSubmission, ERRORS, 1)
           }
         }
 

--- a/test/util/testdata/notifications/NotificationTestData.scala
+++ b/test/util/testdata/notifications/NotificationTestData.scala
@@ -93,6 +93,7 @@ object NotificationTestData {
   val functionCode_3: String = randomResponseFunctionCode
   val nameCode: Option[String] = None
   val errors = Seq(NotificationError(validationCode = "CDS12056", pointer = Some(Pointer(Seq(PointerSection("42A", PointerSectionType.FIELD))))))
+  val errors2 = Seq(NotificationError(validationCode = "CDS12010", pointer = Some(Pointer(Seq(PointerSection("42A", PointerSectionType.FIELD))))))
 
   private val payloadExemplaryLength = 300
   val payload = TestDataHelper.randomAlphanumericString(payloadExemplaryLength)
@@ -100,17 +101,17 @@ object NotificationTestData {
   val notification = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = actionId,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = UNKNOWN, version = Some(1), errors = errors)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued, status = REJECTED, version = Some(1), errors = errors)
   )
   val notification_2 = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = actionId,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_2, status = UNKNOWN, version = Some(1), errors = errors)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_2, status = REJECTED, version = Some(1), errors = errors2)
   )
   val notification_3 = ParsedNotification(
     unparsedNotificationId = UUID.randomUUID,
     actionId = actionId_2,
-    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_3, status = UNKNOWN, version = Some(1), errors = Seq.empty)
+    details = NotificationDetails(mrn = mrn, dateTimeIssued = dateTimeIssued_3, status = RECEIVED, version = Some(1), errors = Seq.empty)
   )
 
   val notificationForExternalAmendment = ParsedNotification(


### PR DESCRIPTION
Creates audit events that reports the returned function codes of the processed notifications and the distinct list of any error codes they contain.