### PR TITLE
CEDS-5592 Fix transformation from ExportsDeclarationRequest

### DIFF
--- a/app/uk/gov/hmrc/exports/migrations/changelogs/cache/AddAssociatedSubmissionIdToDeclarations.scala
+++ b/app/uk/gov/hmrc/exports/migrations/changelogs/cache/AddAssociatedSubmissionIdToDeclarations.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.exports.migrations.changelogs.submission
+package uk.gov.hmrc.exports.migrations.changelogs.cache
 
 import com.mongodb.client.{MongoCollection, MongoDatabase}
 import org.bson.Document
@@ -28,7 +28,7 @@ import scala.jdk.CollectionConverters._
 class AddAssociatedSubmissionIdToDeclarations extends MigrationDefinition with Logging {
 
   override val migrationInformation: MigrationInformation =
-    MigrationInformation(id = s"CEDS-5583 Add AssociatedSubmissionId to declaration meta data", order = 24, author = "Tim Wilkins")
+    MigrationInformation(id = s"CEDS-5583_2 Add AssociatedSubmissionId to declaration meta data", order = 24, author = "Tim Wilkins")
 
   private val declarationMeta = "declarationMeta"
   private val status = "status"

--- a/app/uk/gov/hmrc/exports/models/declaration/ExportsDeclaration.scala
+++ b/app/uk/gov/hmrc/exports/models/declaration/ExportsDeclaration.scala
@@ -63,16 +63,8 @@ object ExportsDeclaration {
     val meta = declarationRequest.declarationMeta
     ExportsDeclaration(
       id = id,
-      declarationMeta = DeclarationMeta(
-        parentDeclarationId = meta.parentDeclarationId,
-        parentDeclarationEnhancedStatus = meta.parentDeclarationEnhancedStatus,
-        status = declarationRequest.consignmentReferences.map(_ => if (meta.status == INITIAL) DRAFT else meta.status).getOrElse(INITIAL),
-        createdDateTime = meta.createdDateTime,
-        updatedDateTime = meta.updatedDateTime,
-        summaryWasVisited = meta.summaryWasVisited,
-        readyForSubmission = meta.readyForSubmission,
-        maxSequenceIds = meta.maxSequenceIds
-      ),
+      declarationMeta =
+        meta.copy(status = declarationRequest.consignmentReferences.map(_ => if (meta.status == INITIAL) DRAFT else meta.status).getOrElse(INITIAL)),
       eori = eori.value,
       `type` = declarationRequest.`type`,
       dispatchLocation = declarationRequest.dispatchLocation,

--- a/test/it/uk/gov/hmrc/exports/migrations/changelogs/submission/AddAssociatedSubmissionToDeclarationsISpec.scala
+++ b/test/it/uk/gov/hmrc/exports/migrations/changelogs/submission/AddAssociatedSubmissionToDeclarationsISpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.exports.migrations.changelogs.submission
 
 import org.bson.Document
 import uk.gov.hmrc.exports.base.IntegrationTestMigrationToolSpec
+import uk.gov.hmrc.exports.migrations.changelogs.cache.AddAssociatedSubmissionIdToDeclarations
 import uk.gov.hmrc.exports.models.declaration.DeclarationStatus._
 
 class AddAssociatedSubmissionIdToDeclarationsISpec extends IntegrationTestMigrationToolSpec {


### PR DESCRIPTION
The ExportsDeclarationRequest was making a field by field copy of the DeclarationMetaData object rather than just copying the entire thing. This resulted in the new `associatedSubmissionId` field being stripped out of any updates to a draft declaration.

I've also renamed the migration job that populates the new `associatedSubmissionId` field so that it runs again in production to re-populate those declarations that will now be missing the new fields.