### PR TITLE
CEDS-5759 Fix Sending invalid XML payload to DEC API for amendments

### DIFF
--- a/app/uk/gov/hmrc/exports/repositories/UpdateSubmissionsTransactionalOps.scala
+++ b/app/uk/gov/hmrc/exports/repositories/UpdateSubmissionsTransactionalOps.scala
@@ -260,12 +260,12 @@ class UpdateSubmissionsTransactionalOps @Inject() (
 
   private def deleteAnyAmendmentDraftDeclaration(
     session: ClientSession,
-    submission: Submission,
-    optSubmission: Option[Submission]
+    preUpdateSubmission: Submission,
+    postUpdateSubmission: Option[Submission]
   ): Future[Option[Submission]] =
-    optSubmission match {
+    postUpdateSubmission match {
       case Some(submissionWithNewAction) =>
-        submission.latestDecId match {
+        preUpdateSubmission.latestDecId match {
           case Some(latestDecId) =>
             val filter = and(
               equal("eori", submissionWithNewAction.eori),
@@ -278,7 +278,6 @@ class UpdateSubmissionsTransactionalOps @Inject() (
         }
 
       case _ =>
-        logger.error(s"Cannot add an (external amendment) 'Action' to Submission(${submission.uuid})")
         Future.successful(None)
     }
 }

--- a/app/uk/gov/hmrc/exports/services/mapping/declaration/AdditionalInformationBuilder.scala
+++ b/app/uk/gov/hmrc/exports/services/mapping/declaration/AdditionalInformationBuilder.scala
@@ -50,7 +50,7 @@ class AdditionalInformationBuilder @Inject() () extends ModifyingBuilder[Exports
   def buildThenAdd(statementDescription: String, declaration: Declaration, sequenceIndex: Int = 1): Unit = {
     val additionalInformation = new Declaration.AdditionalInformation()
     val statementDescriptionTextType = new AdditionalInformationStatementDescriptionTextType()
-    statementDescriptionTextType.setValue(statementDescription.replaceAll("\r", ""))
+    statementDescriptionTextType.setValue(statementDescription.replaceAll("[\\r\\n]+", " ").trim)
 
     val statementTypeCode = new AdditionalInformationStatementTypeCodeType()
     statementTypeCode.setValue("AES")

--- a/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsRunner.scala
+++ b/app/uk/gov/hmrc/exports/services/notifications/receiptactions/NotificationReceiptActionsRunner.scala
@@ -66,7 +66,9 @@ class NotificationReceiptActionsRunner @Inject() (
 
           unparsedNotificationWorkItemRepository.markAs(workItem.id, Cancelled)
         } else {
-          logger.warn(s"[UnparsedNotification parsing] Processing of id(${workItem.item.id}) failed! Error is:\n\t${throwable.getMessage}")
+          logger.warn(
+            s"[UnparsedNotification parsing] Processing of id(${workItem.item.id}) failed! Will reattempt. Error is:\n\t${throwable.getMessage}"
+          )
           unparsedNotificationWorkItemRepository.markAs(workItem.id, Failed)
         }
       }

--- a/test/it/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorISpec.scala
+++ b/test/it/uk/gov/hmrc/exports/connector/CustomsDeclarationsConnectorISpec.scala
@@ -108,6 +108,15 @@ class CustomsDeclarationsConnectorISpec extends IntegrationTestSpec with Exports
         }
       }
 
+      "request is bad - 400" in {
+        val headers = Map("X-Conversation-ID" -> UUID.randomUUID.toString)
+        postToDownstreamService(appConfig.amendDeclarationUri, BAD_REQUEST, None, headers)
+
+        intercept[InternalServerException] {
+          await(connector.submitAmendment(declarantEoriValue, expectedSubmissionRequestPayload(id)))
+        }
+      }
+
       "request is not processed - 500" in {
         val headers = Map("X-Conversation-ID" -> UUID.randomUUID.toString)
         postToDownstreamService(appConfig.amendDeclarationUri, INTERNAL_SERVER_ERROR, None, headers)

--- a/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/AdditionalInformationBuilderSpec.scala
+++ b/test/unit/uk/gov/hmrc/exports/services/mapping/declaration/AdditionalInformationBuilderSpec.scala
@@ -78,7 +78,7 @@ class AdditionalInformationBuilderSpec extends UnitSpec with ExportsItemBuilder 
     }
   }
 
-  "buildThenAdd from just a description" should {
+  "buildThenAdd from just a statement description" should {
 
     "append to declaration" in {
       val declaration = new Declaration()
@@ -97,7 +97,7 @@ class AdditionalInformationBuilderSpec extends UnitSpec with ExportsItemBuilder 
       pointer2.getDocumentSectionCode.getValue mustBe "06A"
     }
 
-    "remove any carriage-return from the description" in {
+    "remove any carriage-return and line feeds from the statement description" in {
       val declaration = new Declaration()
 
       val description = "Some reason1\r\nSome reason2\r\nSome reason3\r\n"
@@ -106,7 +106,7 @@ class AdditionalInformationBuilderSpec extends UnitSpec with ExportsItemBuilder 
       declaration.getAdditionalInformation must have(size(1))
       val additionalInfo = declaration.getAdditionalInformation.get(0)
 
-      val expectedDescription = "Some reason1\nSome reason2\nSome reason3\n"
+      val expectedDescription = "Some reason1 Some reason2 Some reason3"
       additionalInfo.getStatementDescription.getValue mustBe expectedDescription
     }
   }


### PR DESCRIPTION
Replacing line feed and carriage return chars in the amendment `statementDescription` field with space characters to ensure generated XML is schema compliant.

Also fixing error reporting on downstream connector to stop reporting 400s errors as 500s in the logs.

Finally, some logging tweaks:
* stop logging at error level when submission is not updated that we can't delete any associated draft amendments
* add comment that when we fail to process a notification that we will reattempt it.